### PR TITLE
fix hide/show arrow and move delay buttons shifting on toggle

### DIFF
--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -25,10 +25,11 @@
         <% else %>
           <%= link dgettext("study" ,"Unfavorite"), to: Routes.study_path(@conn, :unfavorite_study, @study.slug), method: :post, class: "icon", "data-icon": '"' %>
         <% end %>
+        <br>
 
-        <nobr><a class="icon" data-icon="%" id="arrows_toggle"><%= dgettext("study", "Hide Arrows") %></a></nobr>
-        <nobr><a class="icon" data-icon="%" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>"><%= dgettext("study", "Slow board reset") %></a></nobr>
-        <nobr><a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time"><%= dgettext("study", "instant") %></span></a></nobr>
+        <a class="icon" data-icon="%" id="arrows_toggle"><%= dgettext("study", "Hide Arrows") %></a><br>
+        <a class="icon" data-icon="%" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>"><%= dgettext("study", "Slow board reset") %></a><br>
+        <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time"><%= dgettext("study", "instant") %></span></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #47

This fix puts each button (except the Stockfish and Favourite ones) on a new line.

![image](https://user-images.githubusercontent.com/9111965/109376038-c4106f80-788f-11eb-9edc-1aaf32df1b51.png)


