### PR TITLE
Fix gh-72: "you chess game" -> "your chess game"

### DIFF
--- a/lib/listudy_web/views/helpers/page_title.ex
+++ b/lib/listudy_web/views/helpers/page_title.ex
@@ -31,7 +31,7 @@ defmodule ListudyWeb.PageTitle do
     do: dgettext("page_titles", "Achievements")
 
   defp get(%{view_module: PageView}),
-    do: dgettext("page_titles", "Improve you chess game with spaced repetition")
+    do: dgettext("page_titles", "Improve your chess game with spaced repetition")
 
   defp get(%{view_module: Elixir.ListudyWeb.StudyView, view_template: "show.html", study: study}),
     do: study.title

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -42,7 +42,7 @@ msgid "User Settings"
 msgstr ""
 
 #, elixir-format
-#: lib/listudy/users/user.ex:43
+#: lib/listudy/users/user.ex:50
 msgid "Only alphanumeric characters allowed"
 msgstr ""
 

--- a/priv/gettext/page_titles.pot
+++ b/priv/gettext/page_titles.pot
@@ -31,11 +31,6 @@ msgid "Endgames"
 msgstr ""
 
 #, elixir-format
-#: lib/listudy_web/views/helpers/page_title.ex:34
-msgid "Improve you chess game with spaced repetition"
-msgstr ""
-
-#, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:28
 msgid "Play against Stockfish Online"
 msgstr ""
@@ -63,4 +58,9 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:25
 msgid "Thank you!"
+msgstr ""
+
+#, elixir-format
+#: lib/listudy_web/views/helpers/page_title.ex:34
+msgid "Improve your chess game with spaced repetition"
 msgstr ""


### PR DESCRIPTION
Fixes #72.

Steps taken to make this fix:
- Changed string in `lib/listudy_web/views/helpers/page_title.ex`
- Ran `mix gettext.extract` in my terminal
