### PR TITLE
Redraw chessground only on window width change

### DIFF
--- a/assets/js/blind_tactics.js
+++ b/assets/js/blind_tactics.js
@@ -2,7 +2,7 @@ require("regenerator-runtime/runtime"); // required for sleep (https://github.co
 
 const Chessground = require('chessground').Chessground;
 const Chess = require('chess.js')
-import { resize_ground, setup_ground, ground_set_moves_from_instance, 
+import { resize_ground, onresize, setup_ground, ground_set_moves_from_instance,
          ground_undo_last_move, setup_click_handler, ground_move } from './modules/ground.js';
 import { ground_legal_moves, turn_color, setup_chess, uci_to_san, san_to_uci } from './modules/chess_utils.js';
 import { set_text, clear_all_text, success_div, info_div, error_div, suggestion_div } from './modules/info_boxes.js';
@@ -204,6 +204,6 @@ function main() {
 }
 
 document.addEventListener("phx:update", main);
-window.onresize = resize_ground;
+window.onresize = onresize;
 window.old_pgn = "abc";
 main();

--- a/assets/js/chessclicker.js
+++ b/assets/js/chessclicker.js
@@ -1,6 +1,6 @@
 const Chessground = require('chessground').Chessground;
 const Chess = require('chess.js')
-import { ground_init_state, resize_ground, setup_ground, ground_set_moves, 
+import { ground_init_state, onresize, resize_ground, setup_ground, ground_set_moves,
          ground_undo_last_move, setup_move_handler, ground_move } from './modules/ground.js';
 import { turn_color, setup_chess, uci_to_san, san_to_uci } from './modules/chess_utils.js';
 
@@ -249,7 +249,7 @@ function save() {
 }
 
 document.addEventListener("phx:update", main);
-window.onresize = resize_ground;
+window.onresize = onresize;
 window.old_fen = "abc";
 setup();
 window.setInterval(tick, 1000);

--- a/assets/js/endgames.js
+++ b/assets/js/endgames.js
@@ -10,7 +10,7 @@ import { tree_move_index, tree_children, tree_possible_moves, has_children,
 import { generate_move_trees } from './modules/tree_from_pgn.js';
 import { sleep } from './modules/sleep.js';
 import { unescape_string } from './modules/security_related.js';
-import { ground_init_state, resize_ground, setup_ground, ground_set_moves, 
+import { ground_init_state, onresize, resize_ground, setup_ground, ground_set_moves,
          ground_undo_last_move, setup_move_handler, ground_move } from './modules/ground.js';
 import { set_text, clear_all_text, success_div, info_div, error_div, suggestion_div } from './modules/info_boxes.js';
 
@@ -168,5 +168,5 @@ function main() {
 }
 
 window.main = main;
-window.onresize = resize_ground;
+window.onresize = onresize;
 main();

--- a/assets/js/modules/ground.js
+++ b/assets/js/modules/ground.js
@@ -31,7 +31,21 @@ function setup_click_handler(f) {
 function setup_ground(fen) {
     const config = {};
     window.ground = Chessground(document.getElementById("chessground"), config);
+    window.window_width = window.innerWidth;
     ground_init_state(fen);
+}
+
+/*
+ * Window resize callback
+ */
+function onresize() {
+    // Don't resize ground if the window width is unchanged
+    if (window.innerWidth === window.window_width) {
+        return;
+    }
+
+    window.window_width = window.innerWidth;
+    resize_ground();
 }
 
 // call on window resizing
@@ -164,4 +178,4 @@ function ground_move(m, c = undefined) {
     }
 }
 
-export { ground_init_state, resize_ground, setup_ground, ground_set_moves, ground_set_moves_from_instance, ground_undo_last_move, setup_move_handler, setup_click_handler, ground_move };
+export { ground_init_state, onresize, resize_ground, setup_ground, ground_set_moves, ground_set_moves_from_instance, ground_undo_last_move, setup_move_handler, setup_click_handler, ground_move };

--- a/assets/js/pieceless_tactics.js
+++ b/assets/js/pieceless_tactics.js
@@ -2,7 +2,7 @@ require("regenerator-runtime/runtime"); // required for sleep (https://github.co
 
 const Chessground = require('chessground').Chessground;
 const Chess = require('chess.js')
-import { resize_ground, setup_ground, ground_set_moves, 
+import { onresize, resize_ground, setup_ground, ground_set_moves,
          ground_undo_last_move, setup_move_handler, ground_move } from './modules/ground.js';
 import { ground_legal_moves, turn_color, setup_chess, uci_to_san, san_to_uci } from './modules/chess_utils.js';
 import { set_text, clear_all_text, success_div, info_div, error_div, suggestion_div } from './modules/info_boxes.js';
@@ -168,5 +168,5 @@ function main() {
     setup_give_up();
 }
 
-window.onresize = resize_ground;
+window.onresize = onresize;
 main();

--- a/assets/js/play_stockfish.js
+++ b/assets/js/play_stockfish.js
@@ -10,7 +10,7 @@ import { tree_move_index, tree_children, tree_possible_moves, has_children,
 import { generate_move_trees } from './modules/tree_from_pgn.js';
 import { sleep } from './modules/sleep.js';
 import { unescape_string } from './modules/security_related.js';
-import { ground_init_state, resize_ground, setup_ground, ground_set_moves, 
+import { ground_init_state, onresize, resize_ground, setup_ground, ground_set_moves,
          ground_undo_last_move, setup_move_handler, ground_move } from './modules/ground.js';
 import { set_text, clear_all_text, success_div, info_div, error_div, suggestion_div } from './modules/info_boxes.js';
 
@@ -130,5 +130,5 @@ function main(hash) {
     setup_options();
 }
 
-window.onresize = resize_ground;
+window.onresize = onresize;
 main("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1;p");

--- a/assets/js/study.js
+++ b/assets/js/study.js
@@ -11,7 +11,7 @@ import { generate_move_trees, annotate_pgn } from './modules/tree_from_pgn.js';
 import { sleep } from './modules/sleep.js';
 import { getRandomIntFromRange } from './modules/random.js';
 import { unescape_string } from './modules/security_related.js';
-import { ground_init_state, resize_ground, setup_ground, ground_set_moves,
+import { ground_init_state, onresize, resize_ground, setup_ground, ground_set_moves,
          ground_undo_last_move, setup_move_handler, ground_move } from './modules/ground.js';
 import { set_text, clear_all_text, success_div, info_div, error_div, suggestion_div } from './modules/info_boxes.js';
 
@@ -520,5 +520,5 @@ function main() {
     setup_progress_reset();
 }
 
-window.onresize = resize_ground;
+window.onresize = onresize;
 main();

--- a/assets/js/tactics.js
+++ b/assets/js/tactics.js
@@ -1,6 +1,6 @@
 require("regenerator-runtime/runtime"); // required for sleep (https://github.com/babel/babel/issues/9849#issuecomment-487040428)
 
-import { resize_ground, setup_ground, ground_set_moves, 
+import { onresize, resize_ground, setup_ground, ground_set_moves,
          ground_undo_last_move, setup_move_handler, ground_move } from './modules/ground.js';
 import { setup_chess, uci_to_san } from './modules/chess_utils.js';
 import { set_text, clear_all_text, success_div, info_div, error_div, suggestion_div } from './modules/info_boxes.js';
@@ -101,6 +101,6 @@ function main() {
 }
 
 document.addEventListener("phx:update", main);
-window.onresize = resize_ground;
+window.onresize = onresize;
 window.old_fen = "abc";
 main();


### PR DESCRIPTION
In some mobile browsers, scrolling a page triggers a window resize event (due to the url bar hiding), which redraws the page (`resize_ground`) and resets the page position to the top. I've experienced this with Chrome on Android and Firefox on Android, don't know if this affects other browsers. Since `resize_ground` only cares about width anyway, I think we can trigger this only on window resize when the width changes.

Please let me know if this fix is acceptable, thanks!