### PR TITLE
Some changes in studies, redesign of options and arrows (issue 130 an…

### DIFF
--- a/assets/css/features/study.css
+++ b/assets/css/features/study.css
@@ -49,6 +49,11 @@
 
 .study_option_item_below {
     margin-right: 3rem;
+    min-width: 23ch;
+}
+
+.study_option_item_below > a {
+	display: block;
 }
 
 .select2 {

--- a/assets/css/features/study.css
+++ b/assets/css/features/study.css
@@ -5,6 +5,7 @@
 }
 
 .chapter_selection {
+    margin-top: 0.5em;
     max-width: 230px;
 }
 
@@ -14,6 +15,40 @@
 
 .study_options {
     margin-bottom: 2rem;
+}
+
+@media only screen and (max-width: 600px) {
+    .sidebar_padded {
+        padding-left: 1em;
+    }
+}
+
+.study_options_below {
+    margin-bottom: 2rem;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+@media only screen and (max-width: 600px) {
+    .study_options_below {
+        padding: 1em;
+        display: flex;
+        flex-direction: column;
+    }
+}
+
+.large_clickarea {
+    display: inline-block;
+    width: 90%;
+    position: relative;
+    z-index: 1;
+    padding: 1.5em 1.5em 1.5em 0em;
+    margin: -1.5em -1.5em -1.5em 0em;
+}
+
+.study_option_item_below {
+    margin-right: 3rem;
 }
 
 .select2 {

--- a/assets/js/modules/ground.js
+++ b/assets/js/modules/ground.js
@@ -15,7 +15,10 @@ function ground_init_state(fen) {
     config["fen"] = fen;
     config["highlight"] = { check: true };
     config["lastMove"] = undefined;
-    config["drawable"] = {brushes: {hint: {key: "v", color: "#0034FF", opacity: 1, lineWidth: 10 }}}
+    config["drawable"] = {brushes: {
+        normal: {key: "v", color: "#0034FF", opacity: 1, lineWidth: 10 },
+        transparent: {key: "v", color: "#0034FF", opacity: 0.4, lineWidth: 10 }
+    }};
     ground.set(config);
 }
 

--- a/assets/js/modules/tree_utils.js
+++ b/assets/js/modules/tree_utils.js
@@ -47,7 +47,7 @@ function tree_possible_moves(access, {filter=function(){return true;},sort=funct
     let children = tree_children_filter_sort(access, {filter:filter, sort:sort});
     let moves = [];
     for (let c of children) {
-        moves.push(c.move);
+        moves.push(c);
     }
     return moves;
 }

--- a/assets/js/study.js
+++ b/assets/js/study.js
@@ -157,22 +157,20 @@ function give_hints(access, once) {
     let all_moves = tree_possible_moves(access);
     let min = Math.min(...all_moves.map(m => m.value));
     let max = Math.max(...all_moves.map(m => m.value));
+    let shapes = [];
 
     if (once || show_arrows == i18n.arrows_always ||
         show_arrows == i18n.arrows_new2x && min < 2 ||
         show_arrows == i18n.arrows_new5x && min < 5) {
 
-        let shapes = [];
         for (let m of all_moves) {
             let some_neglected = min < (0.5 * max);
             let brush = some_neglected ? m.value < (0.5 * max) ? "normal" : "transparent" : "normal";
             //console.log(m.move + " (" + m.value + "/" + max + ") min: " + min + " => brush: " + brush)
             shapes.push(create_shape(m.move, brush));
         }
-        ground.setShapes(shapes);
-    } else {
-        ground.setShapes([]);
     }
+    ground.setShapes(shapes);
 }
 
 /*
@@ -267,6 +265,15 @@ function start_training() {
         play_move(ai_move(curr_move));
     }
     setup_move();
+
+    /* TODO figure out how to remove this. This is a workaround to make sure arrows appear right from
+    the start. Without this, setShapes() in give_hints() appear to have no effect. It's only needed the
+    first time hints are displayed, so this is a good location. The redraw scrolls the page to the top
+    on mobile devices, and having the call in give_hints() then forces a scroll to the top every time
+    the user makes a move or changes the Arrows option. Hours have been spent on this bug. Could be a
+    bug in chessground. */
+    ground.redrawAll();
+
     window.mode = mode_free;
 }
 
@@ -402,7 +409,7 @@ function toggle_arrows() {
     }
     span.textContent = curr;
     show_arrows = curr;
-    give_hints(curr_move);
+    give_hints(curr_move, false);
 }
 
 function toggle_key_move() {

--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -5,37 +5,55 @@
     <%= render ListudyWeb.ComponentView, "chessground.html" %>
   </div>
   <div class="sidebar">
-    <%= render ListudyWeb.ComponentView, "infoboxes.html" %>
-    
-    <p id="comments" class="study_comments">
-      <span id="comments_text"></span>
-    </p>
+    <div>
+      <%= render ListudyWeb.ComponentView, "infoboxes.html" %>
 
+      <div class="sidebar_padded">
+        <div style="margin-bottom: 1em">
+          <a class="icon large_clickarea" data-icon="-" id="hints"><%= dgettext("study", "Show hints for this move!") %></a><br>
+        </div>
+        
+        <!-- Putting the <p id="comments"> and <span id="comments_text"> on different lines below causes an extra line break because the "white-space: pre-line" is on the outer <p> -->
+        <p id="comments" class="study_comments"><span id="comments_text"></span></p>
+      </div>
+    </div>
     <div class="study_options">
-      <div class="chapter_selection">
+      <div class="chapter_selection sidebar_padded">
         <label for="chapter_select"><%= dgettext "study", "Chapter Selection" %></label>
         <select id="chapter_select"></select>
-      </div>
-
-      <div>
-        <a class="icon" data-icon="!" id="play_stockfish" href="<%= Routes.page_path(@conn, :play_stockfish, @locale) %>#rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" title="<%= dgettext "study", "Play against Stockfish" %>">Stockfish</a>
-      
-        <%= if !@study.favorites do %>
-          <%= link dgettext("study", "Favorite"), to: Routes.study_path(@conn, :favorite_study, @study.slug), method: :post, class: "icon", "data-icon": "#" %>
-        <% else %>
-          <%= link dgettext("study" ,"Unfavorite"), to: Routes.study_path(@conn, :unfavorite_study, @study.slug), method: :post, class: "icon", "data-icon": '"' %>
-        <% end %>
-        <br>
-
-        <a class="icon" data-icon="%" id="arrows_toggle"><%= dgettext("study", "Hide Arrows") %></a><br>
-        <a class="icon" data-icon="%" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>"><%= dgettext("study", "Slow board reset") %></a><br>
-        <a class="icon" data-icon="$" id="key_move" title="<%= dgettext("study", "Don't repeat the early moves that are already known. Skips to the first branching move in the study.") %>"><%= dgettext("study", "Key Move") %></a><br>
-        <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time"><%= dgettext("study", "instant") %></span></a>
-
         <div id="chapter_progress"></div>
         <a href="#" data-icon="+" class="icon modal_open" id="progress"><%= dgettext("study","Progress") %></a>
       </div>
     </div>
+  </div>
+</div>
+<div class="study_options_below">
+  <div class="study_option_item_below">
+    <a class="icon" data-icon="!" id="play_stockfish" href="<%= Routes.page_path(@conn, :play_stockfish, @locale) %>#rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" title="<%= dgettext "study", "Play against Stockfish" %>"><%= dgettext "study", "Play against Stockfish" %></a>
+  </div>
+
+  <div class="study_option_item_below">
+    <%= if !@study.favorites do %>
+      <%= link dgettext("study", "Favorite study"), to: Routes.study_path(@conn, :favorite_study, @study.slug), method: :post, class: "icon", "data-icon": "#" %>
+    <% else %>
+      <%= link dgettext("study" ,"Unfavorite study"), to: Routes.study_path(@conn, :unfavorite_study, @study.slug), method: :post, class: "icon", "data-icon": '"' %>
+    <% end %>
+  </div>
+
+  <div class="study_option_item_below">
+    <a class="icon" data-icon="(" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>"><%= dgettext("study", "Board reset delay: fast") %></a>
+  </div>
+  <div class="study_option_item_below">
+    <a class="icon" data-icon="$" id="key_move" title="<%= dgettext("study", "Don't repeat the early moves that are already known. Skips to the first branching move in the study.") %>"><%= dgettext("study", "Jump to key move: on") %></a>
+  </div>
+  <div class="study_option_item_below">
+    <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time"><%= dgettext("study", "instant") %></span></a>
+  </div>
+  <div class="study_option_item_below">
+    <a class="icon" data-icon="-" id="arrows_toggle"><%= dgettext("study", "Arrows: until played 2x") %></a>
+  </div>
+  <div class="study_option_item_below">
+    <a class="icon" data-icon="." id="reset_line"><%= dgettext("study", "Reset line") %></a>
   </div>
 </div>
 
@@ -111,12 +129,14 @@
   i18n.suggestion_comment = "<%= dgettext "study", "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below." %>";
   i18n.suggestion_100moves = "<%= dgettext "study", "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect." %>";
   i18n.suggestion_250moves = "<%= raw dgettext "study", "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop." %>";
-  i18n.arrows_hide = "<%= dgettext "study", "Hide Arrows" %>";
-  i18n.arrows_show = "<%= dgettext "study", "Show Arrows" %>";
-  i18n.review_slow = "<%= dgettext "study", "Slow board reset" %>";
-  i18n.review_fast = "<%= dgettext "study", "Fast board reset" %>";
-  i18n.key_move_enabled = "<%= dgettext "study", "Key Move" %>";
-  i18n.key_move_disabled = "<%= dgettext "study", "Key Move" %>";
+  i18n.arrows_new2x = "<%= dgettext "study", "Arrows: until played 2x" %>";
+  i18n.arrows_new5x = "<%= dgettext "study", "Arrows: until played 5x" %>";
+  i18n.arrows_always = "<%= dgettext "study", "Arrows: always on" %>";
+  i18n.arrows_hidden = "<%= dgettext "study", "Arrows: hidden" %>";
+  i18n.review_slow = "<%= dgettext "study", "Board reset delay: fast" %>";
+  i18n.review_fast = "<%= dgettext "study", "Board reset delay: slow" %>";
+  i18n.key_move_enabled = "<%= dgettext "study", "Jump to key move: off" %>";
+  i18n.key_move_disabled = "<%= dgettext "study", "Jump to key move: on" %>";
   i18n.slow = "<%= dgettext "study", "slow" %>";
   i18n.fast = "<%= dgettext "study", "fast" %>";
   i18n.medium = "<%= dgettext "study", "medium" %>";

--- a/priv/gettext/de/LC_MESSAGES/study.po
+++ b/priv/gettext/de/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Zunächst zeigen Ihnen die Pfeile an, welche Züge sich in dieser Studie befinden. Sobald Sie diese Züge zweimal gespielt haben, werden die Pfeile nicht mehr angezeigt."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Am Ende von Linien wird das Brett erst nach 3 Sekunden zurückgesetzt, was Ihnen Zeit gibt, die Endstellung zu überprüfen."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Kapitel"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr "Kapitelauswahl"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Erstellen Sie ein Konto, um alle Funktionen von Listudy zu nutzen und Ihre eigenen Studien hochzuladen."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Ersteller*in"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Beschreibung"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Haben Sie Feedback, Anregungen oder wollen Sie etwas Nettes sagen? Kommentieren Sie die Studie unten."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Gefällt Ihnen diese Studie? Teilen Sie sie mit Ihren Freund*innen."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
-msgstr "Schneller Brett-Reset"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Favorite study"
 msgstr "Favorisieren"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr "Pfeile ausblenden"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Wenn Ihnen diese Studie gefällt, stellen Sie sicher, dass Sie sie favorisieren, damit sie unter Ihre Studien aufgeführt wird"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Zugverzögerung"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Eröffnung"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr "Spielen Sie gegen Stockfish"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Richtiger Zug!"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr "Pfeile einblenden"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr "Langsamer Brett-Reset"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Training starten."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Dieser Zug ist nicht in der Studie, versuchen Sie es erneut."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr "Entfavorisieren"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Sie haben heute 100 Züge gelernt. Vielleicht machen Sie eine Pause oder kommen morgen wieder, um den vollen Trainingseffekt zu erhalten."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Sie haben heute 250 Züge gelernt. Für den besten Trainingseffekt kommen Sie morgen wieder. Oder auch nicht, ich bin nur ein Text und kein Polizist."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Sie haben das Ende dieser Linie erreicht."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "schnell"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "sofort"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "mittel"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "langsam"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Zurück"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr "Caro-Kann Verteidigung"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr "Konnte die Studie nicht von Lichess herunterladen, bitte überprüfen Sie den Link"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr "Konnte diese Studie nicht favorisieren"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr "Konnte diese Studie nicht entfavorisieren"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr "Laden Sie entweder eine PGN-Datei hoch oder geben Sie einen Link zu einer öffentlichen Lichess-Studie an:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr "Für welche Seite ist diese Studie"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr "In dieser Studie arbeite ich an meinen 1.e4-Eröffnungen..."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr "Halten Sie diese Studie privat"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr "Lichess Studie"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr "Keine PGN bereitgestellt"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr "PGN ist zu groß, nur 50kb erlaubt"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr "Bitte melden Sie sich an"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr "Wählen Sie eine PGN zum Hochladen"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr "Studie favorisiert"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr "Studieninfo aktualisiert, PGN geändert."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr "Studieninfo aktualisiert, keine PGN-Änderung."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr "Studie entfavorisiert"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr "Bei dem angegebenen Link handelt es sich nicht um eine Lichess-Studie"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titel"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr "Studie erstellen"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr "Erstellen Sie eine neue Studie und beginnen Sie zu lernen."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr "Favorisierte Studie"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr "Neue Studie"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr "Nach Studien suchen"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr "Ihre Studien"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr "Neue Studie erstellen"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr "Für weitere Informationen lesen Sie die Copyright-Richtlinie"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr "Bitte denken Sie daran, nur PGNs hochzuladen, für die Sie die Rechte haben, sie zu veröffentlichen. Dies gilt insbesondere, aber nicht ausschließlich, für PGN-Dateien, die Sie von kostenpflichtigen Plattformen erworben haben."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr "Studie löschen"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr "Dies kann nicht rückgängig gemacht werden!"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Suchen"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr "Studien durchsuchen"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr "von"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Nicht die frühen Züge, die bereits bekannt sind, wiederholen. Springt zum ersten Verzweigungszug in der Studie."
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr "Favoriten"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr "Key Move"
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr "Neueste"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr "Favoriten"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
+msgstr "Entfavorisieren"

--- a/priv/gettext/de/LC_MESSAGES/study.po
+++ b/priv/gettext/de/LC_MESSAGES/study.po
@@ -66,7 +66,7 @@ msgstr "Bearbeiten"
 #: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
-msgstr "Favorisieren"
+msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
@@ -419,4 +419,4 @@ msgstr ""
 #: lib/listudy_web/templates/study/show.html.eex:39
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
-msgstr "Entfavorisieren"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/study.po
+++ b/priv/gettext/en/LC_MESSAGES/study.po
@@ -64,7 +64,7 @@ msgid "Edit"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/study.po
+++ b/priv/gettext/en/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr ""
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/study.po
+++ b/priv/gettext/es/LC_MESSAGES/study.po
@@ -64,9 +64,9 @@ msgid "Edit"
 msgstr "Editar"
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
-msgstr "Favorito"
+msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
@@ -419,4 +419,4 @@ msgstr ""
 #: lib/listudy_web/templates/study/show.html.eex:39
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
-msgstr "Quitar favorito"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/study.po
+++ b/priv/gettext/es/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: es\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Al principio las flechas te mostrarán qué movimientos pertenecen al estudio. Cuando hayas hecho los movimientos 2 veces, las flechas no se mostrarán."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Al final de las líneas el tablero se reinicia después de 3 segundos, para que puedas revisar la última posición."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Capitulo"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr "Selección de Capitulo"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Crea una cuenta para tener todas las funciones de Listudy y subir tus propios estudios."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Creador"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descripción"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "¿Tienes recomendaciones o quieres decir algo? Comenta en el estudio"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "¿Te gusta este estudio? Compártelo con tus amigos."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Editar"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
-msgstr "Reiniciar tablero"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr "Favorito"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr "Esconder flechas"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Si te gusta este estudio agregalo a tus favoritos para tenerlo listado en Tus Estudios"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Retraso de movimiento:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Apertura"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr "Juega contra Stockfish"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "¡Movimiento correcto!"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr "Mostrar flechas"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr "Reiniciar tablero"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Empezando entrenamiento"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Este movimiento no está en el estudio, intenta de nuevo."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr "Quitar favorito"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Ya aprendiste 100 movimientos hoy. Tal vez toma un descando o vuelve mañana para tener efectos positivos"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Ya aprendiste 250 movimientos hoy. Para tener más efectos positivos vuelve mañana, o no, soy un texto no un policia."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Llegaste al final de esta línea."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rápido"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "instantáneo"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "medio"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "lento"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Atrás"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr "Defensa Caro-Kann"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr "No se pudo descargar el estudio de lichess, por favor revisa el link"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr "No se pudo agregar el estudio a tus favoritos"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr "No se pudo quitar el favorito a este estudio"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr "Sube un archivo PGN o suministra un link de un estudio público en Lichess:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr "¿Para qué bando es el estudio?"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr "En este estudio presento mis aperturas con 1. e4..."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr "Mantener este estudio privado"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr "Estudio de Lichess"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr "No se proporcionó un archivo PGN"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr "El PGN es muy pesado, sólo se permite 50kb máximo"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr "Por favor inicia sesión"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr "Selecciona un PGN para subir"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr "Estudio favorito"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr "Información del estudio actualizada, el PGN cambió."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr "Información del estudio actualizada, sin cambio PGN."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr "Estudio sin favorito"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr "El link suministrado en es un estudio de Lichess"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Título"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr "Crear un Estudio"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr "Crea un nuevo estudio y empieza a aprender."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr "Estudios Favoritos"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr "Nuevo Estudio"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr "Buscar Estudios"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr "Tus Estudios"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr "Crear un nuevo Estudio"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr "Para obtener más información lee la Política de Copyright"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr "Por favor recuerda subir archivos de los que tengas permisos para publicarlos. Esto aplica especialmente a archivos PGN pero no se limita a ello."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "¿Estás seguro?"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Borrar"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr "Borrar Estudio"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr "¡Esto no se puede deshacer!"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Buscar"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr "Buscar estudios"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr "por"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "No repite movimientos que ya se conocen. Salta al primer movimiento del estudio."
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr "Favoritos"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr "Movimiento Clave"
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr "Más Nuevo"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr "favoritos"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
+msgstr "Quitar favorito"

--- a/priv/gettext/fa/LC_MESSAGES/study.po
+++ b/priv/gettext/fa/LC_MESSAGES/study.po
@@ -64,7 +64,7 @@ msgid "Edit"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 

--- a/priv/gettext/fa/LC_MESSAGES/study.po
+++ b/priv/gettext/fa/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: fa\n"
 "Plural-Forms: nplurals=1\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr ""
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/study.po
+++ b/priv/gettext/fr/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: fr\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Au début, les flèches vous montreront quels coups sont dans cette étude. Une fois que vous avez joué ces coups deux fois, les flèches ne sont plus affichées."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "À la fin des coups, le plateau n'est réinitialisé qu'après 3 secondes, ce qui vous laisse le temps de revoir la position finale."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Chapitre"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr "Sélection du chapitre"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Créez un compte pour obtenir toutes les fonctionnalités de Listudy et uploader vos propres études."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Créateur"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Description"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Avez-vous des commentaires, des suggestions ou voulez-vous dire quelque chose de gentil? Commentez l'étude ci-dessous."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Aimez-vous cette étude? Partage-la avec tes amis."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Éditer"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
-msgstr "Réinitialisation rapide du plateau"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Favorite study"
 msgstr "Favoris"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr "Masquer les flèches"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Si vous aimez cette étude, assurez-vous de la mettre en favori pour qu'elle soit répertoriée sous Vos études"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Délai du coup:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Ouverture"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr "Jouer contre Stockfish"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Bon coup!"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr "Afficher les flèches"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr "Réinitialisation lent du plateau"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Début de la formation."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Ce coup n'est pas dans l'étude, réessayez."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr "Enlever des favoris"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Vous avez appris 100 coups aujourd'hui. Faites peut-être une pause ou revenez demain pour profiter pleinement de l'effet de l'entraînement."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Vous avez appris 250 coups aujourd'hui. Pour le meilleur effet d'entraînement, revenez demain. Ou pas, je suis juste un texte pas un flic."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Vous avez atteint la fin de cette ligne."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rapide"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "instant"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "moyen"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "lent"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Retour"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr "Défense Caro-Kann"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr "Impossible de télécharger l'étude de lichess, veuillez vérifier le lien"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr "Impossible de mettre cette étude en favori"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr "Impossible d'enlever cette étude des favoris"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr "Téléchargez un fichier PGN ou fournissez un lien vers une étude publique de Lichess:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr "Pour quelle couleur est cette étude"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr "Dans cette étude je travaille sur mes ouvertures 1.e4..."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr "Gardez cette étude privée"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr "Etude Lichess"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr "Aucun PGN fourni"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr "Le PGN est trop gros, seulement 50 Ko autorisé"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr "Veuillez vous connecter"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr "Sélectionnez un PGN à télécharger"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr "Étude mise dans les favoris"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr "Informations sur l'étude mises à jour, PGN modifié."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr "Informations sur l'étude mises à jour, aucun changement PGN."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr "Etude enlevée des favoris"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr "Le lien fourni n'est pas une étude Lichess"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Titre"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr "Créer une étude"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr "Créer une nouvelle étude et commencer à apprendre."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr "Etudes favorites"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr "Nouvelle édtude"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr "Chercher des études"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr "Vos études"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr "Créer une nouvelle étude"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr "Pour plus d'informations, lisez la politique de Copyright"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr "N'oubliez pas de télécharger uniquement les PGN pour lesquels vous avez le droit de les publier. Cela est particulièrement vrai, mais sans s'y limiter, pour les fichiers PGN que vous avez acquis sur des plateformes payantes."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "Êtes vous sur?"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Supprimer"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr "Supprimer l'étude"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr "Ceci ne peut pas être annulé!"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Chercher"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr "Chercher des études"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr "par"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Ne répétez pas les premiers coups déjà connus. Passe au premier mouvement de branchement dans l'étude."
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr "Favoris"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr "Coup clé"
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr "Les plus récents"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr "favoris"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
+msgstr "Enlever des favoris"

--- a/priv/gettext/fr/LC_MESSAGES/study.po
+++ b/priv/gettext/fr/LC_MESSAGES/study.po
@@ -66,7 +66,7 @@ msgstr "Éditer"
 #: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
-msgstr "Favoris"
+msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
@@ -419,4 +419,4 @@ msgstr ""
 #: lib/listudy_web/templates/study/show.html.eex:39
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
-msgstr "Enlever des favoris"
+msgstr ""

--- a/priv/gettext/he/LC_MESSAGES/study.po
+++ b/priv/gettext/he/LC_MESSAGES/study.po
@@ -64,7 +64,7 @@ msgid "Edit"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 

--- a/priv/gettext/he/LC_MESSAGES/study.po
+++ b/priv/gettext/he/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: he\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr ""
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/study.po
+++ b/priv/gettext/it/LC_MESSAGES/study.po
@@ -64,7 +64,7 @@ msgid "Edit"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 

--- a/priv/gettext/it/LC_MESSAGES/study.po
+++ b/priv/gettext/it/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: it\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr ""
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
 msgstr ""

--- a/priv/gettext/nl/LC_MESSAGES/study.po
+++ b/priv/gettext/nl/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: nl\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr ""
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
 msgstr ""

--- a/priv/gettext/nl/LC_MESSAGES/study.po
+++ b/priv/gettext/nl/LC_MESSAGES/study.po
@@ -64,7 +64,7 @@ msgid "Edit"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 

--- a/priv/gettext/pt/LC_MESSAGES/study.po
+++ b/priv/gettext/pt/LC_MESSAGES/study.po
@@ -64,9 +64,9 @@ msgid "Edit"
 msgstr "Editar"
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
-msgstr "Favorito"
+msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
@@ -419,4 +419,4 @@ msgstr ""
 #: lib/listudy_web/templates/study/show.html.eex:39
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
-msgstr "Remover favorito"
+msgstr ""

--- a/priv/gettext/pt/LC_MESSAGES/study.po
+++ b/priv/gettext/pt/LC_MESSAGES/study.po
@@ -11,331 +11,412 @@ msgstr ""
 "Language: pt\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "A princípio, as setas mostrarão quais movimentos estão neste estudo. Depois de executar esses movimentos duas vezes, as setas não serão mais exibidas."
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "No final das linhas, o tabuleiro só é reiniciado após 3 segundos, dando-lhe tempo para rever a posição final."
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Capítulo"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr "Seleção de capítulo"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Crie uma conta para obter todos os recursos do Listudy e carregue seus próprios estudos."
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Criador(a)"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descrição"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Você tem feedback, sugestões ou quer dizer algo legal? Comente sobre o estudo abaixo."
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Você gosta deste estudo? Compartilhe com seus amigos."
-#, elixir-format
+
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Editar"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
-msgstr "Reinicialização rápida do tabuleiro"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr "Favorito"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr "Esconder setas"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Se você gostar deste estudo, certifique-se de adicioná-lo como favorito para que ele seja listado em Seus estudos"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Atraso nos movimentos de peças:"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Abertura"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr "Jogue contra Stockfish"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Lance correto!"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr "Mostrar setas"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr "Reinicialização lenta do tabuleiro"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Iniciar treinamento."
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Este lance não está no estudo, tente novamente."
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr "Remover favorito"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Você aprendeu 100 movimentos hoje. Faça uma pausa ou volte amanhã para obter o efeito de treinamento completo."
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Você aprendeu 250 movimentos hoje. Para obter o melhor efeito de treinamento, volte amanhã. Ou não, estou apenas enviando uma mensagem e não sou um policial."
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Você chegou ao fim desta linha."
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rápido"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "Instantâneo"
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "médio"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "devagar"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Voltar"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr "Defesa Caro-Kann"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr "Não foi possível baixar o estudo de lichess, por favor, verifique o link"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr "Não foi possível adicionar este estudo como favorito"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr "Não foi possível desfavorecer este estudo"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr "Faça upload de um arquivo PGN ou forneça um link para um estudo público de Lichess:"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr "Para que lado está este estudo"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr "Neste estudo, trabalho em minhas aberturas 1.e4 ..."
-#, elixir-format
+
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr "Manter este estudo privado"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr "Estudo Lichess"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr "Nenhum PGN fornecido"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr "PGN é muito grande, apenas 50kb permitidos"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr "Faça o login por favor"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr "Selecione um PGN para fazer o upload"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr "Estudo adicionado aos favoritos"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr "Informações do estudo atualizadas, PGN alterado."
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr "Informações do estudo atualizadas, sem alteração no PGN."
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr "Estudo desfavorecido"
-#, elixir-format
+
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr "O link fornecido não é um estudo Lichess"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Título"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr "Crie um estudo"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr "Crie um novo estudo e comece a aprender."
-#, elixir-format
+
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr "Estudos preferidos"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr "Novo Estudo"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr "Procurar por estudos"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr "Seus estudos"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr "Criar novo estudo"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr "Para obter mais informações, leia a Política de Direitos Autorais"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr "Lembre-se de fazer upload apenas de PGNs para os quais você tem o direito de publicá-los. Isso é especialmente verdadeiro, mas não limitado, para arquivos PGN que você adquiriu de plataformas pagas."
-#, elixir-format
+
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "Tem certeza?"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Remover"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr "Remover Estudo"
-#, elixir-format
+
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr "Isto não pode ser desfeito!"
-#, elixir-format
+
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Procura"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr "Procurar por estudos"
-#, elixir-format
+
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr "por"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Não repita os primeiros movimentos que já são conhecidos. Pula para o primeiro movimento de ramificação no estudo."
-#, elixir-format
+
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr "Favoritos"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr "Lance Chave"
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr "Mais novo"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr "favoritos"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr "Tem certeza de que deseja excluir seu progresso de estudo?"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr "Progresso"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr "Reiniciar progresso"
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr "Progresso dos estudos"
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
+msgstr "Remover favorito"

--- a/priv/gettext/ru/LC_MESSAGES/study.po
+++ b/priv/gettext/ru/LC_MESSAGES/study.po
@@ -64,7 +64,7 @@ msgid "Edit"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 

--- a/priv/gettext/ru/LC_MESSAGES/study.po
+++ b/priv/gettext/ru/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: ru\n"
 "Plural-Forms: nplurals=3\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr ""
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
 msgstr ""

--- a/priv/gettext/study.pot
+++ b/priv/gettext/study.pot
@@ -69,7 +69,7 @@ msgstr ""
 
 #, elixir-format
 #: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
+msgid "Favorite study"
 msgstr ""
 
 #, elixir-format
@@ -123,11 +123,6 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/study/show.html.eex:104
 msgid "This move is not in the study, try again."
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
 msgstr ""
 
 #, elixir-format

--- a/priv/gettext/tr/LC_MESSAGES/study.po
+++ b/priv/gettext/tr/LC_MESSAGES/study.po
@@ -64,9 +64,9 @@ msgid "Edit"
 msgstr "Düzenle"
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
-msgstr "Favori"
+msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
@@ -419,4 +419,4 @@ msgstr ""
 #: lib/listudy_web/templates/study/show.html.eex:39
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
-msgstr "Favoriden çıkar"
+msgstr ""

--- a/priv/gettext/tr/LC_MESSAGES/study.po
+++ b/priv/gettext/tr/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: tr\n"
 "Plural-Forms: nplurals=2\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Başta, oklar size bu çalışmada hangi hamlelerin olduğunu gösterecek. Bu hamleleri iki kere oynadıktan sonra oklar bir daha gösterilmeyecek."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Hamle serilerinin sonunda son pozisyonu inceleyebilmeniz için tahta 3 saniye sonra sıfırlanır."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Bölüm"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr "Bölüm Seçimi"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Listudy sitesinin tüm özelliklerinden faydalanabilmek ve kendi çalışmalarınızı oluşturabilmek için kayıt olun."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Oluşturan"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Açıklama"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Bir geri dönüşünüz, bir öneriniz veya söyleyecek güzel bir şeyiniz mi var? Aşağıya yorum yapın."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Bu çalışmayı beğendiniz mi? Arkadaşlarınızla paylaşın."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Düzenle"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
-msgstr "Hızlı tahta sıfırlama"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr "Favori"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr "Okları Gizle"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Bu çalışmayı beğendiyseniz favorileyin ve böylece Kendi Çalışmalarınız kısmında görün"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Hamle gecikmesi:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Açılış"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr "Stockfish'e karşı oyna"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Doğru hamle!"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr "Okları Göster"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr "Yavaş tahta sıfırlama"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Alıştırmaya başla."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Bu hamle çalışmada yok, tekrar deneyin."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr "Favoriden çıkar"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Bugün 100 hamle öğrendiniz. Alıştırmadan tam etkiyi almak için belki bir ara verin veya yarın devam edin."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Bugün 250 hamle öğrendiniz. Alıştırmadan en iyi etkiyi almak için yarın devam edin. Veya etmeyin, ben sadece bir metinim, polis değil."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Bu hamle serisinin sonuna ulaştınız."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "hızlı"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "anında"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "orta"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "yavaş"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Geri"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr "Caro-Kann Savunması"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr "Çalışma lichess'ten indirilemedi, lütfen linki kontrol edin"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr "Bu çalışma favorilenemedi"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr "Bu çalışma favoriden çıkarılamadı"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr "Ya bir PGN dosyası yükleyin ya da bir halka açık Lichess çalışmasının linkini verin:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr "Bu çalışma hangi taraf için"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr "Bu çalışmada 1.e4 açılışlarını inceleyeceğim..."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr "Bu çalışmayı gizli tut"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr "Lichess Çalışması"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr "PGN yüklenmedi"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr "PGN çok büyük, maksimum 50KB olabilir"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr "Lütfen giriş yapın"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr "Yüklemek için bir PGN seçin"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr "Çalışma favorilendi"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr "Çalışma bilgisi güncellendi, PGN değiştirildi."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr "Çalışma bilgisi güncellendi, PGN değiştirilmedi."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr "Çalışma favoriden çıkarıldı"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr "Verdiğiniz link bir Lichess çalışmasına ait değil"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Başlık"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr "Bir Çalışma Yarat"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr "Bir çalışma yarat ve öğrenmeye başla."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr "Favorilenmiş Çalışmalar"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr "Yeni Çalışma"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr "Çalışma Ara"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr "Çalışmalarınız"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr "Yeni bir Çalışma yarat"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr "Detaylı bilgi için Telif Hakkı İlkesini okuyun"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr "Lütfen sadece yayınlamaya hakkınız olduğu PGN dosyalarını yüklemeyi unutmayın. Bu özellikle, ancak sınırlı olmayarak, paralı platformlardan elde ettiğiniz PGN dosyaları için geçerlidir."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "Emin misiniz?"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Sil"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr "Çalışmayı Sil"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr "Geri döndürülemez!"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Ara"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr "Çalışma ara"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr "yayınlayan"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Zaten bilinen erken hamleleri tekrar etmeyin. Çalışmadaki ilk dallanan hamleye atlar."
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr "Favoriler"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr "Kilit Hamle"
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr "En yeni"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr "favoriler"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
+msgstr "Favoriden çıkar"

--- a/priv/gettext/vi/LC_MESSAGES/study.po
+++ b/priv/gettext/vi/LC_MESSAGES/study.po
@@ -64,9 +64,9 @@ msgid "Edit"
 msgstr "Sửa"
 
 #: lib/listudy_web/templates/study/show.html.eex:37
-#, elixir-autogen, elixir-format, fuzzy
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
-msgstr "Yêu thích"
+msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
@@ -419,4 +419,4 @@ msgstr ""
 #: lib/listudy_web/templates/study/show.html.eex:39
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
-msgstr "Không yêu thích"
+msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/study.po
+++ b/priv/gettext/vi/LC_MESSAGES/study.po
@@ -11,386 +11,412 @@ msgstr ""
 "Language: vi\n"
 "Plural-Forms: nplurals=1\n"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:121
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Lúc đầu, các mũi tên sẽ cho bạn thấy những động tác nào trong bài học này. Một khi bạn đã chơi các động tác này hai lần, các mũi tên không còn được hiển thị nữa."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Ở cuối dòng, bàn cờ chỉ được đặt lại sau 3 giây cho bạn thời gian để xem lại vị trí cuối cùng."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Chương"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr "Lựa chọn chương"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Tạo một tài khoản để có được tất cả các tính năng của Listudy và tải lên các bài học của riêng bạn."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Người tạo ra"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:62
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Miêu tả"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Bạn có phản hồi, đề xuất hay bạn muốn nói điều gì đó tốt đẹp? Bình luận về bài học dưới đây."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Bạn có thích bài học này không? Chia sẻ nó với bạn bè của bạn."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:66
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Sửa"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
-msgstr "Đặt lại nhanh bàn cờ"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
-msgid "Favorite"
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Favorite study"
 msgstr "Yêu thích"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr "Ẩn mũi tên"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Nếu bạn thích bài học này, hãy chọn yêu thích nó để nó được liệt kê trong bài học của bạn"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:50
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Nước đi chậm:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Khai cuộc"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr "Chơi chống lại Stockfish"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "nước đi đúng!"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr "Hiện mũi tên"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr "Thiết lập lại bàn cờ chậm"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:120
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Bắt đầu tập."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:122
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Nước đi này không có trong bài học, hãy thử lại."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:26
-msgid "Unfavorite"
-msgstr "Không yêu thích"
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Hôm nay bạn đã học được 100 nước đi. Có thể nghỉ ngơi hoặc trở lại vào ngày mai để có được hiệu quả tập luyện tốt."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Hôm nay bạn đã học được 250 nước đi. Để có hiệu quả tập luyện tốt nhất sẽ trở lại vào ngày mai. Hoặc không, tôi chỉ nhắn tin chứ không phải cảnh sát."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Bạn đã đi đến cuối dòng này."
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "nhanh"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "ngay"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "vừa"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "chậm"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr "Quay lại"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr "Phòng thủ Caro-Kann"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr "Không thể tải xuống bài học từ lichess, vui lòng kiểm tra link"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr "Không thể yêu thích bài học này"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr "Không thể không ưa thích bài học này"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr "Tải lên tệp PGN hoặc cung cấp link đến bài học Lichess công khai:"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr "Bài học này cho quân bên nào"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr "Giữ bài học này riêng tư"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr "Bài học Lichess"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr "Không có PGN được cung cấp"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr "PGN quá lớn, chỉ được phép 50kb"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr "Vui lòng đăng nhập"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr "Chọn PGN để tải lên"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr "Bài học được yêu thích"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr "Thông tin bài học được cập nhật, PGN đã thay đổi."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr "Thông tin bài học được cập nhật, PGN không thay đổi."
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr "Bài học không ưa thích"
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr "Link được cung cấp không phải là một bài học của Lichess"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr "Tiêu đề"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr "Tạo một bài học"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr "Tạo một bài học mới và bắt đầu học."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr "Các bài học ưa thích"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr "Bài học mới"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr "Tìm kiếm bài học"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr "Các bài học của bạn"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr "Tạo một bài học mới"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr "Để biết thêm thông tin, hãy đọc chính sách bản quyền"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr "Xin lưu ý chỉ tải lên PGN mà bạn có quyền xuất bản chúng. Điều này đặc biệt đúng, nhưng không giới hạn, đối với các tệp PGN mà bạn đã mua từ các nền tảng trả phí."
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "Bạn có chắc không?"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Xóa"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr "Xóa bài học"
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr "Điều này không thể làm lại"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Tìm kiếm"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr "Tìm kiếm các bài học"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr "của"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:47
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Đừng lặp lại những nước đi ban đầu đã được biết đến. Bỏ qua nước đi phân nhánh đầu tiên trong bài học."
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr "Yêu thích"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr "Nước đi chính"
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr "Mới nhất"
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr "yêu thích"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr "Bạn có chắc chắn muốn xóa tiến trình học tập của bạn?"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr "Tiến bộ"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:152
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr "Đặt lại tiến độ"
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:150
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr "Tiến độ học tập"
+
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:53
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:56
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:39
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
+msgstr "Không yêu thích"


### PR DESCRIPTION
Alright, here is most of the work from this weekend. I tried to split it up into multiple PR's but it turned out to be trickier than I had expected, so I am sorry about that. I will try to be more disciplined in any future PRs. This implements all the changes from both issue 130 and 132, so pretty much everything we have talked about.

To summarize:

- **Redesign of the options section.** The options are now below the chess board.
- **All arrows in a position are now shown, or none at all**, compared to before when only arrows for moves that hadn't been played more than two times were shown.
- **The option for showing arrows is now a multi-value option**, with two options that show arrows until all moves in the position have been played 2 times, and 5 times, as well as always showing all arrows, and never showing them.
- **A "Show hints for this move!" link has been added** that shows all arrows regardless of the currently selected arrow option. It has been given a slightly larger click area to be easy to hit quickly with the mouse or a finger on a mobile phone.
- **A "Reset line" option has been added**, which takes the user back to the starting position.
- **Renaming some options**, ie "Stockfish", "Favorite", "Show/hide arrows" "Slow/fast board reset", and "Key move" have been given slightly different names to be more clear.
- **Very minor issue with comments taking up an extra lines was fixed.** They are now trimmed of whitespaces and that extra empty is removed, gaining some space.

Note 1)  I just realized that there is a value limit of 5 in the tree. I hadn't seen that before. That kind of made my code for showing neglected moves somewhat moot. But I think it fulfills a purpose anyway even if it's just until move 5.

Note 2)  I used the mix gettext.extract --merge command to sync the pot/po files, but only checked in the study-files. The new version of this tool adds a bunch of elixir-autogen comments, and moves the existing comments one line, and updates the lines numbers obviously. So it looks complicated but viewed in a different diff viewer than GitHub perhaps there aren't really that many changes. But I think this was a safer way to do it than manually editing the files. And everything seems to work as far as I can tell.

Note 3)  I figured you are best suited to go into the german file and just search for msgstr "" and fill in those strings that don't have a translation. If you want to I could fill in the rest using Google Translate. You tell me.

Note 4)  There appears to be a bug when resetting progress where it doesn't always reset the values in the tree. I couldn't figure it out but might write an issue on it for later.