### PR TITLE
Link to analyze the position with Lichess Analysis Board

### DIFF
--- a/assets/js/study.js
+++ b/assets/js/study.js
@@ -203,8 +203,16 @@ function change_play_stockfish() {
     link.href = `${base}#${fen}`;
 }
 
+function change_analysis_board() {
+    let pgn = encodeURIComponent(chess.pgn());
+    let color = turn_color(chess);
+    let link = document.getElementById("analysis_board");
+    link.href = `https://lichess.org/analysis/pgn/${pgn}?color=${color}`;
+}
+
 function setup_move() {
     change_play_stockfish();
+    change_analysis_board();
     give_hints(curr_move, false);
     show_suggestions();
     display_comments(curr_move);

--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -33,6 +33,11 @@
   </div>
 
   <div class="study_option_item_below">
+    <a class="icon" data-icon="/" id="analysis_board" href="https://lichess.org/analysis"
+    title="<%= dgettext "study", "Analyze this position with the Lichess Analysis Board" %>"><%= dgettext "study", "Analyze position" %></a>
+  </div>
+
+  <div class="study_option_item_below">
     <%= if !@study.favorites do %>
       <%= link dgettext("study", "Favorite study"), to: Routes.study_path(@conn, :favorite_study, @study.slug), method: :post, class: "icon", "data-icon": "#" %>
     <% else %>

--- a/priv/gettext/de/LC_MESSAGES/study.po
+++ b/priv/gettext/de/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Zunächst zeigen Ihnen die Pfeile an, welche Züge sich in dieser Studie befinden. Sobald Sie diese Züge zweimal gespielt haben, werden die Pfeile nicht mehr angezeigt."
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Am Ende von Linien wird das Brett erst nach 3 Sekunden zurückgesetzt, was Ihnen Zeit gibt, die Endstellung zu überprüfen."
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Kapitel"
@@ -31,55 +31,55 @@ msgstr "Kapitel"
 msgid "Chapter Selection"
 msgstr "Kapitelauswahl"
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Erstellen Sie ein Konto, um alle Funktionen von Listudy zu nutzen und Ihre eigenen Studien hochzuladen."
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Ersteller*in"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Beschreibung"
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Haben Sie Feedback, Anregungen oder wollen Sie etwas Nettes sagen? Kommentieren Sie die Studie unten."
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Gefällt Ihnen diese Studie? Teilen Sie sie mit Ihren Freund*innen."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Wenn Ihnen diese Studie gefällt, stellen Sie sicher, dass Sie sie favorisieren, damit sie unter Ihre Studien aufgeführt wird"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Zugverzögerung"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Eröffnung"
@@ -90,53 +90,53 @@ msgstr "Eröffnung"
 msgid "Play against Stockfish"
 msgstr "Spielen Sie gegen Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Richtiger Zug!"
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Training starten."
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Dieser Zug ist nicht in der Studie, versuchen Sie es erneut."
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Sie haben heute 100 Züge gelernt. Vielleicht machen Sie eine Pause oder kommen morgen wieder, um den vollen Trainingseffekt zu erhalten."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Sie haben heute 250 Züge gelernt. Für den besten Trainingseffekt kommen Sie morgen wieder. Oder auch nicht, ich bin nur ein Text und kein Polizist."
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Sie haben das Ende dieser Linie erreicht."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "schnell"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "sofort"
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "mittel"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "langsam"
@@ -322,7 +322,7 @@ msgstr "Studien durchsuchen"
 msgid "by"
 msgstr "von"
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Nicht die frühen Züge, die bereits bekannt sind, wiederholen. Springt zum ersten Verzweigungszug in der Studie."
@@ -343,7 +343,7 @@ msgstr "Neueste"
 msgid "favorites"
 msgstr "Favoriten"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/study.po
+++ b/priv/gettext/en/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,55 +31,55 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,53 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/study.po
+++ b/priv/gettext/es/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: es\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Al principio las flechas te mostrarán qué movimientos pertenecen al estudio. Cuando hayas hecho los movimientos 2 veces, las flechas no se mostrarán."
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Al final de las líneas el tablero se reinicia después de 3 segundos, para que puedas revisar la última posición."
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Capitulo"
@@ -31,55 +31,55 @@ msgstr "Capitulo"
 msgid "Chapter Selection"
 msgstr "Selección de Capitulo"
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Crea una cuenta para tener todas las funciones de Listudy y subir tus propios estudios."
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Creador"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descripción"
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "¿Tienes recomendaciones o quieres decir algo? Comenta en el estudio"
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "¿Te gusta este estudio? Compártelo con tus amigos."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Editar"
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Si te gusta este estudio agregalo a tus favoritos para tenerlo listado en Tus Estudios"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Retraso de movimiento:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Apertura"
@@ -90,53 +90,53 @@ msgstr "Apertura"
 msgid "Play against Stockfish"
 msgstr "Juega contra Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "¡Movimiento correcto!"
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Empezando entrenamiento"
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Este movimiento no está en el estudio, intenta de nuevo."
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Ya aprendiste 100 movimientos hoy. Tal vez toma un descando o vuelve mañana para tener efectos positivos"
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Ya aprendiste 250 movimientos hoy. Para tener más efectos positivos vuelve mañana, o no, soy un texto no un policia."
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Llegaste al final de esta línea."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rápido"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "instantáneo"
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "medio"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "lento"
@@ -322,7 +322,7 @@ msgstr "Buscar estudios"
 msgid "by"
 msgstr "por"
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "No repite movimientos que ya se conocen. Salta al primer movimiento del estudio."
@@ -343,7 +343,7 @@ msgstr "Más Nuevo"
 msgid "favorites"
 msgstr "favoritos"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/fa/LC_MESSAGES/study.po
+++ b/priv/gettext/fa/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: fa\n"
 "Plural-Forms: nplurals=1\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,55 +31,55 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,53 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/study.po
+++ b/priv/gettext/fr/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: fr\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Au début, les flèches vous montreront quels coups sont dans cette étude. Une fois que vous avez joué ces coups deux fois, les flèches ne sont plus affichées."
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "À la fin des coups, le plateau n'est réinitialisé qu'après 3 secondes, ce qui vous laisse le temps de revoir la position finale."
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Chapitre"
@@ -31,55 +31,55 @@ msgstr "Chapitre"
 msgid "Chapter Selection"
 msgstr "Sélection du chapitre"
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Créez un compte pour obtenir toutes les fonctionnalités de Listudy et uploader vos propres études."
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Créateur"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Description"
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Avez-vous des commentaires, des suggestions ou voulez-vous dire quelque chose de gentil? Commentez l'étude ci-dessous."
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Aimez-vous cette étude? Partage-la avec tes amis."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Éditer"
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Si vous aimez cette étude, assurez-vous de la mettre en favori pour qu'elle soit répertoriée sous Vos études"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Délai du coup:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Ouverture"
@@ -90,53 +90,53 @@ msgstr "Ouverture"
 msgid "Play against Stockfish"
 msgstr "Jouer contre Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Bon coup!"
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Début de la formation."
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Ce coup n'est pas dans l'étude, réessayez."
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Vous avez appris 100 coups aujourd'hui. Faites peut-être une pause ou revenez demain pour profiter pleinement de l'effet de l'entraînement."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Vous avez appris 250 coups aujourd'hui. Pour le meilleur effet d'entraînement, revenez demain. Ou pas, je suis juste un texte pas un flic."
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Vous avez atteint la fin de cette ligne."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rapide"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "instant"
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "moyen"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "lent"
@@ -322,7 +322,7 @@ msgstr "Chercher des études"
 msgid "by"
 msgstr "par"
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Ne répétez pas les premiers coups déjà connus. Passe au premier mouvement de branchement dans l'étude."
@@ -343,7 +343,7 @@ msgstr "Les plus récents"
 msgid "favorites"
 msgstr "favoris"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/he/LC_MESSAGES/study.po
+++ b/priv/gettext/he/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: he\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,55 +31,55 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,53 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/study.po
+++ b/priv/gettext/it/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: it\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,55 +31,55 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,53 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/nl/LC_MESSAGES/study.po
+++ b/priv/gettext/nl/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: nl\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,55 +31,55 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,53 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/pt/LC_MESSAGES/study.po
+++ b/priv/gettext/pt/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: pt\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "A princípio, as setas mostrarão quais movimentos estão neste estudo. Depois de executar esses movimentos duas vezes, as setas não serão mais exibidas."
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "No final das linhas, o tabuleiro só é reiniciado após 3 segundos, dando-lhe tempo para rever a posição final."
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Capítulo"
@@ -31,55 +31,55 @@ msgstr "Capítulo"
 msgid "Chapter Selection"
 msgstr "Seleção de capítulo"
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Crie uma conta para obter todos os recursos do Listudy e carregue seus próprios estudos."
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Criador(a)"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descrição"
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Você tem feedback, sugestões ou quer dizer algo legal? Comente sobre o estudo abaixo."
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Você gosta deste estudo? Compartilhe com seus amigos."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Editar"
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Se você gostar deste estudo, certifique-se de adicioná-lo como favorito para que ele seja listado em Seus estudos"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Atraso nos movimentos de peças:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Abertura"
@@ -90,53 +90,53 @@ msgstr "Abertura"
 msgid "Play against Stockfish"
 msgstr "Jogue contra Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Lance correto!"
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Iniciar treinamento."
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Este lance não está no estudo, tente novamente."
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Você aprendeu 100 movimentos hoje. Faça uma pausa ou volte amanhã para obter o efeito de treinamento completo."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Você aprendeu 250 movimentos hoje. Para obter o melhor efeito de treinamento, volte amanhã. Ou não, estou apenas enviando uma mensagem e não sou um policial."
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Você chegou ao fim desta linha."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rápido"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "Instantâneo"
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "médio"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "devagar"
@@ -322,7 +322,7 @@ msgstr "Procurar por estudos"
 msgid "by"
 msgstr "por"
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Não repita os primeiros movimentos que já são conhecidos. Pula para o primeiro movimento de ramificação no estudo."
@@ -343,7 +343,7 @@ msgstr "Mais novo"
 msgid "favorites"
 msgstr "favoritos"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr "Tem certeza de que deseja excluir seu progresso de estudo?"
@@ -353,60 +353,65 @@ msgstr "Tem certeza de que deseja excluir seu progresso de estudo?"
 msgid "Progress"
 msgstr "Progresso"
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr "Reiniciar progresso"
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr "Progresso dos estudos"
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/study.po
+++ b/priv/gettext/ru/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: ru\n"
 "Plural-Forms: nplurals=3\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,55 +31,55 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,53 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
@@ -343,7 +343,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/study.pot
+++ b/priv/gettext/study.pot
@@ -10,381 +10,422 @@
 msgid ""
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:103
+#: lib/listudy_web/templates/study/show.html.eex:124
+#, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
+#: lib/listudy_web/templates/study/show.html.eex:48
+#, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:107
+#: lib/listudy_web/templates/study/show.html.eex:128
+#, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:16
+#: lib/listudy_web/templates/study/show.html.eex:22
+#, elixir-autogen, elixir-format
 msgid "Chapter Selection"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:110
+#: lib/listudy_web/templates/study/show.html.eex:131
+#, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:72
+#, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:65
+#, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:111
+#: lib/listudy_web/templates/study/show.html.eex:132
+#, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:109
+#: lib/listudy_web/templates/study/show.html.eex:130
+#, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:69
+#, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:117
-msgid "Fast board reset"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:24
+#: lib/listudy_web/templates/study/show.html.eex:42
+#, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:30
-#: lib/listudy_web/templates/study/show.html.eex:114
-msgid "Hide Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:108
+#: lib/listudy_web/templates/study/show.html.eex:129
+#, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
+#: lib/listudy_web/templates/study/show.html.eex:54
+#, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:75
+#, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:21
+#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:105
+#: lib/listudy_web/templates/study/show.html.eex:126
+#, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:115
-msgid "Show Arrows"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:31
-#: lib/listudy_web/templates/study/show.html.eex:116
-msgid "Slow board reset"
-msgstr ""
-
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:102
+#: lib/listudy_web/templates/study/show.html.eex:123
+#, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:104
+#: lib/listudy_web/templates/study/show.html.eex:125
+#, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:112
+#: lib/listudy_web/templates/study/show.html.eex:133
+#, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:113
+#: lib/listudy_web/templates/study/show.html.eex:134
+#, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:106
+#: lib/listudy_web/templates/study/show.html.eex:127
+#, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:144
+#, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:33
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
+#, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:145
+#, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:143
+#, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:70
+#, elixir-autogen, elixir-format
 msgid "Back"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:269
+#, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:295
+#, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:313
+#, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:20
+#, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:38
+#, elixir-autogen, elixir-format
 msgid "For which side is this study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:43
+#, elixir-autogen, elixir-format
 msgid "Keep this study private"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:28
+#, elixir-autogen, elixir-format
 msgid "Lichess Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:278
+#, elixir-autogen, elixir-format
 msgid "No PGN provided"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:245
+#, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:227
+#, elixir-autogen, elixir-format
 msgid "Please log in"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:23
+#, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:292
+#, elixir-autogen, elixir-format
 msgid "Study favorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:171
+#, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:178
+#, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:310
+#, elixir-autogen, elixir-format
 msgid "Study unfavorited"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/controllers/study_controller.ex:273
+#, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/form.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Title"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:14
+#, elixir-autogen, elixir-format
 msgid "Create a Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:13
+#, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Favored Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "New Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:15
+#, elixir-autogen, elixir-format
 msgid "Search for Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/index.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Your Studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:1
+#, elixir-autogen, elixir-format
 msgid "Create a new Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:9
+#, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/new.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:33
+#, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:31
+#, elixir-autogen, elixir-format
 msgid "Delete Study"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/templates/study/edit.html.eex:32
+#, elixir-autogen, elixir-format
 msgid "This can not be undone!"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:12
+#, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:10
+#, elixir-autogen, elixir-format
 msgid "Search for studies"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "by"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
+#: lib/listudy_web/templates/study/show.html.eex:51
+#, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:14
+#, elixir-autogen, elixir-format
 msgid "Favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:32
-#: lib/listudy_web/templates/study/show.html.eex:118 lib/listudy_web/templates/study/show.html.eex:119
-msgid "Key Move"
-msgstr ""
-
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:15
+#, elixir-autogen, elixir-format
 msgid "Newest"
 msgstr ""
 
-#, elixir-format
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
+#, elixir-autogen, elixir-format
 msgid "favorites"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:147
+#, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:36
+#: lib/listudy_web/templates/study/show.html.eex:25
+#, elixir-autogen, elixir-format
 msgid "Progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:155
+#, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#, elixir-format
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:153
+#, elixir-autogen, elixir-format
 msgid "Study Progress"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze this position with the Lichess Analysis Board"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:137
+#, elixir-autogen, elixir-format
+msgid "Arrows: always on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:138
+#, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: off"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
+#, elixir-autogen, elixir-format
+msgid "Jump to key move: on"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:60
+#, elixir-autogen, elixir-format
+msgid "Reset line"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:13
+#, elixir-autogen, elixir-format
+msgid "Show hints for this move!"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:44
+#, elixir-autogen, elixir-format
+msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/tr/LC_MESSAGES/study.po
+++ b/priv/gettext/tr/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: tr\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Başta, oklar size bu çalışmada hangi hamlelerin olduğunu gösterecek. Bu hamleleri iki kere oynadıktan sonra oklar bir daha gösterilmeyecek."
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Hamle serilerinin sonunda son pozisyonu inceleyebilmeniz için tahta 3 saniye sonra sıfırlanır."
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Bölüm"
@@ -31,55 +31,55 @@ msgstr "Bölüm"
 msgid "Chapter Selection"
 msgstr "Bölüm Seçimi"
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Listudy sitesinin tüm özelliklerinden faydalanabilmek ve kendi çalışmalarınızı oluşturabilmek için kayıt olun."
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Oluşturan"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Açıklama"
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Bir geri dönüşünüz, bir öneriniz veya söyleyecek güzel bir şeyiniz mi var? Aşağıya yorum yapın."
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Bu çalışmayı beğendiniz mi? Arkadaşlarınızla paylaşın."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Düzenle"
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Bu çalışmayı beğendiyseniz favorileyin ve böylece Kendi Çalışmalarınız kısmında görün"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Hamle gecikmesi:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Açılış"
@@ -90,53 +90,53 @@ msgstr "Açılış"
 msgid "Play against Stockfish"
 msgstr "Stockfish'e karşı oyna"
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Doğru hamle!"
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Alıştırmaya başla."
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Bu hamle çalışmada yok, tekrar deneyin."
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Bugün 100 hamle öğrendiniz. Alıştırmadan tam etkiyi almak için belki bir ara verin veya yarın devam edin."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Bugün 250 hamle öğrendiniz. Alıştırmadan en iyi etkiyi almak için yarın devam edin. Veya etmeyin, ben sadece bir metinim, polis değil."
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Bu hamle serisinin sonuna ulaştınız."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "hızlı"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "anında"
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "orta"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "yavaş"
@@ -322,7 +322,7 @@ msgstr "Çalışma ara"
 msgid "by"
 msgstr "yayınlayan"
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Zaten bilinen erken hamleleri tekrar etmeyin. Çalışmadaki ilk dallanan hamleye atlar."
@@ -343,7 +343,7 @@ msgstr "En yeni"
 msgid "favorites"
 msgstr "favoriler"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,60 +353,65 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/study.po
+++ b/priv/gettext/vi/LC_MESSAGES/study.po
@@ -11,17 +11,17 @@ msgstr ""
 "Language: vi\n"
 "Plural-Forms: nplurals=1\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:121
+#: lib/listudy_web/templates/study/show.html.eex:124
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Lúc đầu, các mũi tên sẽ cho bạn thấy những động tác nào trong bài học này. Một khi bạn đã chơi các động tác này hai lần, các mũi tên không còn được hiển thị nữa."
 
-#: lib/listudy_web/templates/study/show.html.eex:44
+#: lib/listudy_web/templates/study/show.html.eex:48
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Ở cuối dòng, bàn cờ chỉ được đặt lại sau 3 giây cho bạn thời gian để xem lại vị trí cuối cùng."
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:128
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Chương"
@@ -31,55 +31,55 @@ msgstr "Chương"
 msgid "Chapter Selection"
 msgstr "Lựa chọn chương"
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Tạo một tài khoản để có được tất cả các tính năng của Listudy và tải lên các bài học của riêng bạn."
 
-#: lib/listudy_web/templates/study/show.html.eex:69
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Người tạo ra"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:62
+#: lib/listudy_web/templates/study/show.html.eex:65
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Miêu tả"
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Bạn có phản hồi, đề xuất hay bạn muốn nói điều gì đó tốt đẹp? Bình luận về bài học dưới đây."
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Bạn có thích bài học này không? Chia sẻ nó với bạn bè của bạn."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:69
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Sửa"
 
-#: lib/listudy_web/templates/study/show.html.eex:37
+#: lib/listudy_web/templates/study/show.html.eex:42
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:129
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Nếu bạn thích bài học này, hãy chọn yêu thích nó để nó được liệt kê trong bài học của bạn"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
+#: lib/listudy_web/templates/study/show.html.eex:54
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
 msgstr "Nước đi chậm:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:72
+#: lib/listudy_web/templates/study/show.html.eex:75
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Khai cuộc"
@@ -90,53 +90,53 @@ msgstr "Khai cuộc"
 msgid "Play against Stockfish"
 msgstr "Chơi chống lại Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:123
+#: lib/listudy_web/templates/study/show.html.eex:126
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "nước đi đúng!"
 
-#: lib/listudy_web/templates/study/show.html.eex:120
+#: lib/listudy_web/templates/study/show.html.eex:123
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Bắt đầu tập."
 
-#: lib/listudy_web/templates/study/show.html.eex:122
+#: lib/listudy_web/templates/study/show.html.eex:125
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Nước đi này không có trong bài học, hãy thử lại."
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Hôm nay bạn đã học được 100 nước đi. Có thể nghỉ ngơi hoặc trở lại vào ngày mai để có được hiệu quả tập luyện tốt."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Hôm nay bạn đã học được 250 nước đi. Để có hiệu quả tập luyện tốt nhất sẽ trở lại vào ngày mai. Hoặc không, tôi chỉ nhắn tin chứ không phải cảnh sát."
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:127
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Bạn đã đi đến cuối dòng này."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "nhanh"
 
-#: lib/listudy_web/templates/study/show.html.eex:50
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:54
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "ngay"
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "vừa"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "chậm"
@@ -322,7 +322,7 @@ msgstr "Tìm kiếm các bài học"
 msgid "by"
 msgstr "của"
 
-#: lib/listudy_web/templates/study/show.html.eex:47
+#: lib/listudy_web/templates/study/show.html.eex:51
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
 msgstr "Đừng lặp lại những nước đi ban đầu đã được biết đến. Bỏ qua nước đi phân nhánh đầu tiên trong bài học."
@@ -343,7 +343,7 @@ msgstr "Mới nhất"
 msgid "favorites"
 msgstr "yêu thích"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr "Bạn có chắc chắn muốn xóa tiến trình học tập của bạn?"
@@ -353,60 +353,65 @@ msgstr "Bạn có chắc chắn muốn xóa tiến trình học tập của bạ
 msgid "Progress"
 msgstr "Tiến bộ"
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr "Đặt lại tiến độ"
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr "Tiến độ học tập"
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:37
 #, elixir-autogen, elixir-format
-msgid "Arrows: always on"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:135
-#, elixir-autogen, elixir-format
-msgid "Arrows: hidden"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:53
-#: lib/listudy_web/templates/study/show.html.eex:132
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 2x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:133
-#, elixir-autogen, elixir-format
-msgid "Arrows: until played 5x"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:44
-#: lib/listudy_web/templates/study/show.html.eex:136
-#, elixir-autogen, elixir-format
-msgid "Board reset delay: fast"
+msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
-msgid "Board reset delay: slow"
+msgid "Arrows: always on"
 msgstr ""
 
 #: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
+msgid "Arrows: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:57
+#: lib/listudy_web/templates/study/show.html.eex:135
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 2x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:136
+#, elixir-autogen, elixir-format
+msgid "Arrows: until played 5x"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:48
+#: lib/listudy_web/templates/study/show.html.eex:139
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: fast"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:140
+#, elixir-autogen, elixir-format
+msgid "Board reset delay: slow"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:141
+#, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:47
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:51
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:56
+#: lib/listudy_web/templates/study/show.html.eex:60
 #, elixir-autogen, elixir-format
 msgid "Reset line"
 msgstr ""
@@ -416,7 +421,12 @@ msgstr ""
 msgid "Show hints for this move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:39
+#: lib/listudy_web/templates/study/show.html.eex:44
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:37
+#, elixir-autogen, elixir-format
+msgid "Analyze position"
 msgstr ""


### PR DESCRIPTION
Here is the analysis board link feature.

Note. I had forgotten to include priv/gettext/study.pot after running mix gettext.extract --merge --no-fuzzy last time so that's why it contains some changes. Other than that, the language files just contain updated line numbers and the two new text strings for the analysis board link.