### PR TITLE
Storing options in localstorage

### DIFF
--- a/assets/js/modules/localstorage.js
+++ b/assets/js/modules/localstorage.js
@@ -46,4 +46,18 @@ function clear_local_storage() {
     to_remove.forEach(remove_tree);
 }
 
-export { clear_local_storage };
+/**
+ * Gets an option by key from local storage. Also verifies the key is one of the allowed values
+ * in case the code has changed since the user used the app last time. In such case it falls back
+ * on the default value.
+ */
+function get_option_from_localstorage(key, default_value, allowed_values = undefined) {
+    let ls_value = localStorage.getItem(key);
+    if (ls_value && (allowed_values == undefined || allowed_values.indexOf(ls_value) >= 0)) {
+        return ls_value
+    } else {
+        return default_value;
+    }
+}
+
+export { clear_local_storage, get_option_from_localstorage };

--- a/assets/js/study.js
+++ b/assets/js/study.js
@@ -671,20 +671,20 @@ async function setup_progress_reset() {
  */
 function set_options_values() {
     let move_delay = document.getElementById("move_delay_time");
-    move_delay.innerHTML = move_delay_time;
+    move_delay.innerText = move_delay_time;
 
     let arrows_toggle = document.getElementById("arrows_toggle");
-    arrows_toggle.innerHTML = show_arrows;
+    arrows_toggle.innerText = show_arrows;
 
     let line_review = document.getElementById("line_review");
-    line_review.innerHTML = board_review;
+    line_review.innerText = board_review;
 
     let key_move = document.getElementById("key_move");
-    key_move.innerHTML = key_moves_mode;
+    key_move.innerText = key_moves_mode;
     key_move.setAttribute("data-icon", key_moves_mode == i18n.key_move_enabled ? "$" : "%");
 
     let comments_toggle = document.getElementById("comments_toggle");
-    comments_toggle.innerHTML = show_comments;
+    comments_toggle.innerText = show_comments;
 }
 
 function setup_configs() {

--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -45,19 +45,19 @@
     <% end %>
   </div>
   <div class="study_option_item_below">
-    <a class="icon" data-icon="-" id="arrows_toggle"><%= dgettext("study", "Arrows: until played 2x") %></a>
+    <a class="icon" data-icon="-" id="arrows_toggle">placeholder</a>
   </div>
   <div class="study_option_item_below">
-    <a class="icon" data-icon="3" id="comments_toggle" title="<%= dgettext("study", "Option to control when comments are displayed") %>"><%= dgettext("study", "Comments: when arrows show") %></a>
+    <a class="icon" data-icon="3" id="comments_toggle" title="<%= dgettext("study", "Option to control when comments are displayed") %>">placeholder</a>
   </div>
   <div class="study_option_item_below">
-    <a class="icon" data-icon="(" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>"><%= dgettext("study", "Board reset delay: fast") %></a>
+    <a class="icon" data-icon="(" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>">placeholder</a>
   </div>
   <div class="study_option_item_below">
-    <a class="icon" data-icon="$" id="key_move" title="<%= dgettext("study", "Don't repeat the early moves that are already known. Skips to the first branching move in the study.") %>"><%= dgettext("study", "Jump to key move: on") %></a>
+    <a class="icon" data-icon="$" id="key_move" title="<%= dgettext("study", "Don't repeat the early moves that are already known. Skips to the first branching move in the study.") %>">placeholder</a>
   </div>
   <div class="study_option_item_below">
-    <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time"><%= dgettext("study", "instant") %></span></a>
+    <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time">placeholder</span></a>
   </div>
 </div>
 
@@ -137,10 +137,10 @@
   i18n.arrows_new5x = "<%= dgettext "study", "Arrows: until played 5x" %>";
   i18n.arrows_always = "<%= dgettext "study", "Arrows: always on" %>";
   i18n.arrows_hidden = "<%= dgettext "study", "Arrows: hidden" %>";
-  i18n.review_slow = "<%= dgettext "study", "Board reset delay: fast" %>";
-  i18n.review_fast = "<%= dgettext "study", "Board reset delay: slow" %>";
-  i18n.key_move_enabled = "<%= dgettext "study", "Jump to key move: off" %>";
-  i18n.key_move_disabled = "<%= dgettext "study", "Jump to key move: on" %>";
+  i18n.review_slow = "<%= dgettext "study", "Board reset delay: slow" %>";
+  i18n.review_fast = "<%= dgettext "study", "Board reset delay: fast" %>";
+  i18n.key_move_enabled = "<%= dgettext "study", "Jump to key move: on" %>";
+  i18n.key_move_disabled = "<%= dgettext "study", "Jump to key move: off" %>";
   i18n.slow = "<%= dgettext "study", "slow" %>";
   i18n.fast = "<%= dgettext "study", "fast" %>";
   i18n.medium = "<%= dgettext "study", "medium" %>";


### PR DESCRIPTION
Hopefully this one is a little simpler. I've changed so that the options are now stored in local storage. I had it prepared since before.

I changed the remaining two options that used a boolean to store the option to a translation key instead so all options follow the same pattern, and it was also easier to store a text string in local storage.

Also, another quirk. I think the value of key_move_(enabled|disabled) and review_(slow|fast) had been reversed so I changed them. For example, the text of key_move_enabled was "Jump to key move: off" so I changed it to "on" instead so that the translation key correctly conveys what it means. In toggle_key_move() there was a similar mix-up which undid the confusion with the translation key. So everything worked before but the boolean value was just the reverse of what the option said.

And added a fallback in the switch-cases just to be safe if an option change name in the future.

BTW, I've got this option prepared as well. Do you want it? I can put up a PR as soon as this one is merged.

![image](https://user-images.githubusercontent.com/41130048/204654159-16959dcf-8814-4aa1-889d-1a3fbbebec82.png)
