### PR TITLE
Option to set max-depth

### DIFF
--- a/assets/css/features/study.css
+++ b/assets/css/features/study.css
@@ -124,5 +124,5 @@
 }
 
 .option-highlighted a {
-    color: red;
+    color: var(--warn-color);
 }

--- a/assets/css/features/study.css
+++ b/assets/css/features/study.css
@@ -107,8 +107,8 @@
     display: inline-block;
     position: relative;
     z-index: 1;
-    padding: 0.4em;
-    margin: -0.4em;
+    padding: 0.3em;
+    margin: -0.3em;
 
     /* Make it non-selectable */
     -webkit-user-select: none; /* Safari */
@@ -121,4 +121,8 @@
     margin-top: 3px;
     margin-bottom: unset;
     vertical-align: text-bottom;
+}
+
+.option-highlighted a {
+    color: red;
 }

--- a/assets/css/features/study.css
+++ b/assets/css/features/study.css
@@ -49,7 +49,7 @@
 
 .study_option_item_below {
     margin-right: 3rem;
-    min-width: 23ch;
+    min-width: 24ch;
 }
 
 .study_option_item_below > a {
@@ -93,4 +93,28 @@
 .study_progress {
     overflow-y: scroll;
     max-height: 20em;
+}
+
+.max_depth_label {
+    display: inline-block;
+    min-width: 2ch;
+}
+
+.max_depth_ctrl {
+    /* This all make the click area a little larger */
+    display: inline-block;
+    position: relative;
+    z-index: 1;
+    padding: 0.4em;
+    margin: -0.4em;
+
+    /* Make it non-selectable */
+    -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none; /* Standard syntax */
+}
+
+.max_depth_range {
+    width: 50px;
+    margin-top: 3px;
 }

--- a/assets/css/features/study.css
+++ b/assets/css/features/study.css
@@ -101,6 +101,8 @@
 }
 
 .max_depth_ctrl {
+    min-width: 1ch;
+
     /* This all make the click area a little larger */
     display: inline-block;
     position: relative;
@@ -117,4 +119,6 @@
 .max_depth_range {
     width: 50px;
     margin-top: 3px;
+    margin-bottom: unset;
+    vertical-align: text-bottom;
 }

--- a/assets/js/modules/localstorage.js
+++ b/assets/js/modules/localstorage.js
@@ -51,10 +51,16 @@ function clear_local_storage() {
  * in case the code has changed since the user used the app last time. In such case it falls back
  * on the default value.
  */
-function get_option_from_localstorage(key, default_value, allowed_values = undefined) {
+function get_option_from_localstorage(key, default_value, allowed_values = undefined, {validate=function(){return true;},transform=function(f){return f;}}={
+    validate:function(){return true;},
+    transform:function(f){return f;}
+} ) {
+
     let ls_value = localStorage.getItem(key);
-    if (ls_value && (allowed_values == undefined || allowed_values.indexOf(ls_value) >= 0)) {
-        return ls_value
+    let is_allowed_value = allowed_values == undefined || allowed_values.indexOf(ls_value) >= 0;
+    let transformed_value = transform(ls_value);
+    if (ls_value && is_allowed_value && validate(transformed_value)) {
+        return ls_value;
     } else {
         return default_value;
     }

--- a/assets/js/modules/localstorage.js
+++ b/assets/js/modules/localstorage.js
@@ -50,6 +50,9 @@ function clear_local_storage() {
  * Gets an option by key from local storage. Also verifies the key is one of the allowed values
  * in case the code has changed since the user used the app last time. In such case it falls back
  * on the default value.
+ *
+ * Pass a validate function to provide custom validation of the read value from local storage.
+ * Pass a transform function to provide custom transformation of the value, such as convering to a number etc.
  */
 function get_option_from_localstorage(key, default_value, allowed_values = undefined, {validate=function(){return true;},transform=function(f){return f;}}={
     validate:function(){return true;},
@@ -59,8 +62,8 @@ function get_option_from_localstorage(key, default_value, allowed_values = undef
     let ls_value = localStorage.getItem(key);
     let is_allowed_value = allowed_values == undefined || allowed_values.indexOf(ls_value) >= 0;
     let transformed_value = transform(ls_value);
-    if (ls_value && is_allowed_value && validate(transformed_value)) {
-        return ls_value;
+    if (transformed_value && is_allowed_value && validate(transformed_value)) {
+        return transformed_value;
     } else {
         return default_value;
     }

--- a/assets/js/modules/tree_utils.js
+++ b/assets/js/modules/tree_utils.js
@@ -134,12 +134,13 @@ function tree_max_depth(tree) {
 
 /**
  * Returns maximum tree depth in terms of moves (two turns = one move) for an array of moves,
- * such as the starting position of a game.
+ * such as the starting position of a game, from either white's or black's perspective.
  */
-function tree_max_num_moves_deep(start_moves) { 
-    let child_node_depths = start_moves.map(m => tree_max_depth(m));
-    let max_depth = 1 + Math.max(...child_node_depths);
-    return Math.floor((max_depth) / 2);
+function tree_max_num_moves_deep(start_moves, for_white) { 
+    let node_depths = start_moves.map(m => tree_max_depth(m));
+    let max_node_depths = Math.max(...node_depths);
+    let moves_float = max_node_depths / 2;
+    return for_white == true ? Math.ceil(moves_float) : Math.floor(moves_float);
 }
 
 /*

--- a/assets/js/modules/tree_utils.js
+++ b/assets/js/modules/tree_utils.js
@@ -120,6 +120,28 @@ function tree_get_node_depth(access) {
     return access.move_index == 0 ? 1 : 1 + Math.floor(access.move_index / 2);
 }
 
+/**
+ * Returns maximum tree depth in terms of turns (white + black = two turns)
+ */
+function tree_max_depth(tree) { 
+    if (tree.children == undefined || tree.children.length == 0) {
+        return 1;
+    } else {
+        let child_depths = tree.children.map(x => tree_max_depth(x));
+        return 1 + Math.max(...child_depths);
+    }
+}
+
+/**
+ * Returns maximum tree depth in terms of moves (two turns = one move) for an array of moves,
+ * such as the starting position of a game.
+ */
+function tree_max_num_moves_deep(start_moves) { 
+    let child_node_depths = start_moves.map(m => tree_max_depth(m));
+    let max_depth = 1 + Math.max(...child_node_depths);
+    return Math.floor((max_depth) / 2);
+}
+
 /*
  * Get a string representation of a move in SAN notation with move number for debugging purposes, ie 1.e4, or 1...e5
  */
@@ -283,4 +305,4 @@ function tree_value_add(tree, number) {
 }
 
 
-export { tree_value_add, tree_progress, tree_children, tree_children_filter_sort, tree_possible_moves, tree_move_index, has_children, need_hint, update_value, date_sort, value_sort, tree_get_node, tree_value, tree_size, tree_size_weighted_random_move, tree_get_node_depth, tree_get_node_string };
+export { tree_value_add, tree_progress, tree_children, tree_children_filter_sort, tree_possible_moves, tree_move_index, has_children, need_hint, update_value, date_sort, value_sort, tree_get_node, tree_value, tree_size, tree_size_weighted_random_move, tree_get_node_depth, tree_get_node_string, tree_max_num_moves_deep };

--- a/assets/js/study.js
+++ b/assets/js/study.js
@@ -429,7 +429,8 @@ function setup_chapter_select() {
     let select_key = study_id + "_selected";
     let select_id = "chapter_select"
     let select = document.getElementById(select_id);
-    let selected = localStorage.getItem(select_key) || 0;
+    let selected = parseInt(localStorage.getItem(select_key) || 0);
+    selected = Math.min(selected, trees.length - 1);  // prevent error if replacing with a pgn with fewer chapters
     window.chapter = selected;
     for (let i = 0; i < trees.length; ++i) {
         let option = document.createElement("option");

--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -10,7 +10,7 @@
 
       <div class="sidebar_padded">
         <div style="margin-bottom: 1em">
-          <a class="icon large_clickarea" data-icon="-" id="hints"><%= dgettext("study", "Show hints for this move!") %></a><br>
+          <a class="icon large_clickarea" data-icon="-" id="hints" role="button"><%= dgettext("study", "Show hints for this move!") %></a><br>
         </div>
         
         <div id="comments" class="study_comments"></div>
@@ -58,6 +58,13 @@
   </div>
   <div class="study_option_item_below">
     <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time">placeholder</span></a>
+  </div>
+  <div class="study_option_item_below">
+  <div title="<%= dgettext("study", "Limits the number of moves that it is played. One move is when both white and black has moved something on the board.") %>">
+    <a class="icon" data-icon="+"><%= dgettext("study", "Max depth: ") %></a>
+    <a id="max_depth_label" class="max_depth_label">placeholder</a>
+    <a id="max_depth_sub" class="max_depth_ctrl" role="button">-</a><input type="range" id="max_depth_range" class="max_depth_range" min="1" max="1"><a id="max_depth_add" class="max_depth_ctrl" role="button">+</a>
+  </div>
   </div>
 </div>
 
@@ -150,6 +157,7 @@
   i18n.comments_hidden = "<%= dgettext "study", "Comments: hidden" %>";
   i18n.confirm_reset_progress = "<%= dgettext "study", "Are you sure you want to delete your study progress?" %>";
   i18n.response = "<%= dgettext "study", "response" %>";
+  i18n.max_depth = "<%= dgettext "study", "Max depth: " %>";
 </script>
 
 <div id="progress_modal" class="modal">

--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -60,7 +60,7 @@
     <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time">placeholder</span></a>
   </div>
   <div class="study_option_item_below">
-    <div title="<%= dgettext("study", "Limits the number of moves that it is played. One move is when both white and black has moved something on the board.") %>">
+    <div id="max_depth_container" title="<%= dgettext("study", "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire.") %>">
       <a class="icon" data-icon="+"><%= dgettext("study", "Max depth: ") %></a>
       <a id="max_depth_label" class="max_depth_label">placeholder</a>
       <a id="max_depth_sub" class="max_depth_ctrl" role="button">-</a><input type="range" id="max_depth_range" class="max_depth_range" min="1" max="1"><a id="max_depth_add" class="max_depth_ctrl" role="button">+</a>

--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -60,14 +60,13 @@
     <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time">placeholder</span></a>
   </div>
   <div class="study_option_item_below">
-  <div title="<%= dgettext("study", "Limits the number of moves that it is played. One move is when both white and black has moved something on the board.") %>">
-    <a class="icon" data-icon="+"><%= dgettext("study", "Max depth: ") %></a>
-    <a id="max_depth_label" class="max_depth_label">placeholder</a>
-    <a id="max_depth_sub" class="max_depth_ctrl" role="button">-</a><input type="range" id="max_depth_range" class="max_depth_range" min="1" max="1"><a id="max_depth_add" class="max_depth_ctrl" role="button">+</a>
-  </div>
+    <div title="<%= dgettext("study", "Limits the number of moves that it is played. One move is when both white and black has moved something on the board.") %>">
+      <a class="icon" data-icon="+"><%= dgettext("study", "Max depth: ") %></a>
+      <a id="max_depth_label" class="max_depth_label">placeholder</a>
+      <a id="max_depth_sub" class="max_depth_ctrl" role="button">-</a><input type="range" id="max_depth_range" class="max_depth_range" min="1" max="1"><a id="max_depth_add" class="max_depth_ctrl" role="button">+</a>
+    </div>
   </div>
 </div>
-
 
 <div class="highlight">
   <b><%= dgettext "study", "Description" %></b>

--- a/priv/gettext/de/LC_MESSAGES/study.po
+++ b/priv/gettext/de/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Zunächst zeigen Ihnen die Pfeile an, welche Züge sich in dieser Studie befinden. Sobald Sie diese Züge zweimal gespielt haben, werden die Pfeile nicht mehr angezeigt."
@@ -21,7 +21,7 @@ msgstr "Zunächst zeigen Ihnen die Pfeile an, welche Züge sich in dieser Studie
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Am Ende von Linien wird das Brett erst nach 3 Sekunden zurückgesetzt, was Ihnen Zeit gibt, die Endstellung zu überprüfen."
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Kapitel"
@@ -31,34 +31,34 @@ msgstr "Kapitel"
 msgid "Chapter Selection"
 msgstr "Kapitelauswahl"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Erstellen Sie ein Konto, um alle Funktionen von Listudy zu nutzen und Ihre eigenen Studien hochzuladen."
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Ersteller*in"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Beschreibung"
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Haben Sie Feedback, Anregungen oder wollen Sie etwas Nettes sagen? Kommentieren Sie die Studie unten."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Gefällt Ihnen diese Studie? Teilen Sie sie mit Ihren Freund*innen."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -68,7 +68,7 @@ msgstr "Bearbeiten"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Wenn Ihnen diese Studie gefällt, stellen Sie sicher, dass Sie sie favorisieren, damit sie unter Ihre Studien aufgeführt wird"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Zugverzögerung"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Eröffnung"
@@ -90,53 +90,52 @@ msgstr "Eröffnung"
 msgid "Play against Stockfish"
 msgstr "Spielen Sie gegen Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Richtiger Zug!"
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Training starten."
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Dieser Zug ist nicht in der Studie, versuchen Sie es erneut."
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Sie haben heute 100 Züge gelernt. Vielleicht machen Sie eine Pause oder kommen morgen wieder, um den vollen Trainingseffekt zu erhalten."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Sie haben heute 250 Züge gelernt. Für den besten Trainingseffekt kommen Sie morgen wieder. Oder auch nicht, ich bin nur ein Text und kein Polizist."
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Sie haben das Ende dieser Linie erreicht."
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "schnell"
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "sofort"
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "mittel"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "langsam"
@@ -343,7 +342,7 @@ msgstr "Neueste"
 msgid "favorites"
 msgstr "Favoriten"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/de/LC_MESSAGES/study.po
+++ b/priv/gettext/de/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Zunächst zeigen Ihnen die Pfeile an, welche Züge sich in dieser Studie befinden. Sobald Sie diese Züge zweimal gespielt haben, werden die Pfeile nicht mehr angezeigt."
@@ -21,7 +21,7 @@ msgstr "Zunächst zeigen Ihnen die Pfeile an, welche Züge sich in dieser Studie
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Am Ende von Linien wird das Brett erst nach 3 Sekunden zurückgesetzt, was Ihnen Zeit gibt, die Endstellung zu überprüfen."
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Kapitel"
@@ -31,34 +31,34 @@ msgstr "Kapitel"
 msgid "Chapter Selection"
 msgstr "Kapitelauswahl"
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Erstellen Sie ein Konto, um alle Funktionen von Listudy zu nutzen und Ihre eigenen Studien hochzuladen."
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Ersteller*in"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Beschreibung"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Haben Sie Feedback, Anregungen oder wollen Sie etwas Nettes sagen? Kommentieren Sie die Studie unten."
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Gefällt Ihnen diese Studie? Teilen Sie sie mit Ihren Freund*innen."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -68,7 +68,7 @@ msgstr "Bearbeiten"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Wenn Ihnen diese Studie gefällt, stellen Sie sicher, dass Sie sie favorisieren, damit sie unter Ihre Studien aufgeführt wird"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Zugverzögerung"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Eröffnung"
@@ -90,52 +90,52 @@ msgstr "Eröffnung"
 msgid "Play against Stockfish"
 msgstr "Spielen Sie gegen Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Richtiger Zug!"
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Training starten."
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Dieser Zug ist nicht in der Studie, versuchen Sie es erneut."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Sie haben heute 100 Züge gelernt. Vielleicht machen Sie eine Pause oder kommen morgen wieder, um den vollen Trainingseffekt zu erhalten."
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Sie haben heute 250 Züge gelernt. Für den besten Trainingseffekt kommen Sie morgen wieder. Oder auch nicht, ich bin nur ein Text und kein Polizist."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Sie haben das Ende dieser Linie erreicht."
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "schnell"
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "sofort"
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "mittel"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "langsam"
@@ -342,7 +342,7 @@ msgstr "Neueste"
 msgid "favorites"
 msgstr "Favoriten"
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/study.po
+++ b/priv/gettext/en/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -343,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/study.po
+++ b/priv/gettext/en/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,52 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/study.po
+++ b/priv/gettext/es/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: es\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Al principio las flechas te mostrarán qué movimientos pertenecen al estudio. Cuando hayas hecho los movimientos 2 veces, las flechas no se mostrarán."
@@ -21,7 +21,7 @@ msgstr "Al principio las flechas te mostrarán qué movimientos pertenecen al es
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Al final de las líneas el tablero se reinicia después de 3 segundos, para que puedas revisar la última posición."
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Capitulo"
@@ -31,34 +31,34 @@ msgstr "Capitulo"
 msgid "Chapter Selection"
 msgstr "Selección de Capitulo"
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Crea una cuenta para tener todas las funciones de Listudy y subir tus propios estudios."
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Creador"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descripción"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "¿Tienes recomendaciones o quieres decir algo? Comenta en el estudio"
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "¿Te gusta este estudio? Compártelo con tus amigos."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Editar"
@@ -68,7 +68,7 @@ msgstr "Editar"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Si te gusta este estudio agregalo a tus favoritos para tenerlo listado en Tus Estudios"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Retraso de movimiento:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Apertura"
@@ -90,52 +90,52 @@ msgstr "Apertura"
 msgid "Play against Stockfish"
 msgstr "Juega contra Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "¡Movimiento correcto!"
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Empezando entrenamiento"
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Este movimiento no está en el estudio, intenta de nuevo."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Ya aprendiste 100 movimientos hoy. Tal vez toma un descando o vuelve mañana para tener efectos positivos"
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Ya aprendiste 250 movimientos hoy. Para tener más efectos positivos vuelve mañana, o no, soy un texto no un policia."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Llegaste al final de esta línea."
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rápido"
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "instantáneo"
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "medio"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "lento"
@@ -342,7 +342,7 @@ msgstr "Más Nuevo"
 msgid "favorites"
 msgstr "favoritos"
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/study.po
+++ b/priv/gettext/es/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: es\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Al principio las flechas te mostrarán qué movimientos pertenecen al estudio. Cuando hayas hecho los movimientos 2 veces, las flechas no se mostrarán."
@@ -21,7 +21,7 @@ msgstr "Al principio las flechas te mostrarán qué movimientos pertenecen al es
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Al final de las líneas el tablero se reinicia después de 3 segundos, para que puedas revisar la última posición."
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Capitulo"
@@ -31,34 +31,34 @@ msgstr "Capitulo"
 msgid "Chapter Selection"
 msgstr "Selección de Capitulo"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Crea una cuenta para tener todas las funciones de Listudy y subir tus propios estudios."
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Creador"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descripción"
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "¿Tienes recomendaciones o quieres decir algo? Comenta en el estudio"
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "¿Te gusta este estudio? Compártelo con tus amigos."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Editar"
@@ -68,7 +68,7 @@ msgstr "Editar"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Si te gusta este estudio agregalo a tus favoritos para tenerlo listado en Tus Estudios"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Retraso de movimiento:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Apertura"
@@ -90,53 +90,52 @@ msgstr "Apertura"
 msgid "Play against Stockfish"
 msgstr "Juega contra Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "¡Movimiento correcto!"
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Empezando entrenamiento"
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Este movimiento no está en el estudio, intenta de nuevo."
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Ya aprendiste 100 movimientos hoy. Tal vez toma un descando o vuelve mañana para tener efectos positivos"
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Ya aprendiste 250 movimientos hoy. Para tener más efectos positivos vuelve mañana, o no, soy un texto no un policia."
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Llegaste al final de esta línea."
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rápido"
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "instantáneo"
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "medio"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "lento"
@@ -343,7 +342,7 @@ msgstr "Más Nuevo"
 msgid "favorites"
 msgstr "favoritos"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:161
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,23 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
-#, elixir-autogen, elixir-format
-msgid "Comments: always off"
-msgstr ""
-
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -457,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
-msgid "move"
+msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/fa/LC_MESSAGES/study.po
+++ b/priv/gettext/fa/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: fa\n"
 "Plural-Forms: nplurals=1\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,52 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/fa/LC_MESSAGES/study.po
+++ b/priv/gettext/fa/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: fa\n"
 "Plural-Forms: nplurals=1\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -343,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/study.po
+++ b/priv/gettext/fr/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: fr\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Au début, les flèches vous montreront quels coups sont dans cette étude. Une fois que vous avez joué ces coups deux fois, les flèches ne sont plus affichées."
@@ -21,7 +21,7 @@ msgstr "Au début, les flèches vous montreront quels coups sont dans cette étu
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "À la fin des coups, le plateau n'est réinitialisé qu'après 3 secondes, ce qui vous laisse le temps de revoir la position finale."
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Chapitre"
@@ -31,34 +31,34 @@ msgstr "Chapitre"
 msgid "Chapter Selection"
 msgstr "Sélection du chapitre"
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Créez un compte pour obtenir toutes les fonctionnalités de Listudy et uploader vos propres études."
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Créateur"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Description"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Avez-vous des commentaires, des suggestions ou voulez-vous dire quelque chose de gentil? Commentez l'étude ci-dessous."
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Aimez-vous cette étude? Partage-la avec tes amis."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Éditer"
@@ -68,7 +68,7 @@ msgstr "Éditer"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Si vous aimez cette étude, assurez-vous de la mettre en favori pour qu'elle soit répertoriée sous Vos études"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Délai du coup:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Ouverture"
@@ -90,52 +90,52 @@ msgstr "Ouverture"
 msgid "Play against Stockfish"
 msgstr "Jouer contre Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Bon coup!"
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Début de la formation."
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Ce coup n'est pas dans l'étude, réessayez."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Vous avez appris 100 coups aujourd'hui. Faites peut-être une pause ou revenez demain pour profiter pleinement de l'effet de l'entraînement."
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Vous avez appris 250 coups aujourd'hui. Pour le meilleur effet d'entraînement, revenez demain. Ou pas, je suis juste un texte pas un flic."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Vous avez atteint la fin de cette ligne."
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rapide"
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "instant"
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "moyen"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "lent"
@@ -342,7 +342,7 @@ msgstr "Les plus récents"
 msgid "favorites"
 msgstr "favoris"
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/study.po
+++ b/priv/gettext/fr/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: fr\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Au début, les flèches vous montreront quels coups sont dans cette étude. Une fois que vous avez joué ces coups deux fois, les flèches ne sont plus affichées."
@@ -21,7 +21,7 @@ msgstr "Au début, les flèches vous montreront quels coups sont dans cette étu
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "À la fin des coups, le plateau n'est réinitialisé qu'après 3 secondes, ce qui vous laisse le temps de revoir la position finale."
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Chapitre"
@@ -31,34 +31,34 @@ msgstr "Chapitre"
 msgid "Chapter Selection"
 msgstr "Sélection du chapitre"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Créez un compte pour obtenir toutes les fonctionnalités de Listudy et uploader vos propres études."
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Créateur"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Description"
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Avez-vous des commentaires, des suggestions ou voulez-vous dire quelque chose de gentil? Commentez l'étude ci-dessous."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Aimez-vous cette étude? Partage-la avec tes amis."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Éditer"
@@ -68,7 +68,7 @@ msgstr "Éditer"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Si vous aimez cette étude, assurez-vous de la mettre en favori pour qu'elle soit répertoriée sous Vos études"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Délai du coup:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Ouverture"
@@ -90,53 +90,52 @@ msgstr "Ouverture"
 msgid "Play against Stockfish"
 msgstr "Jouer contre Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Bon coup!"
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Début de la formation."
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Ce coup n'est pas dans l'étude, réessayez."
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Vous avez appris 100 coups aujourd'hui. Faites peut-être une pause ou revenez demain pour profiter pleinement de l'effet de l'entraînement."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Vous avez appris 250 coups aujourd'hui. Pour le meilleur effet d'entraînement, revenez demain. Ou pas, je suis juste un texte pas un flic."
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Vous avez atteint la fin de cette ligne."
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rapide"
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "instant"
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "moyen"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "lent"
@@ -343,7 +342,7 @@ msgstr "Les plus récents"
 msgid "favorites"
 msgstr "favoris"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/he/LC_MESSAGES/study.po
+++ b/priv/gettext/he/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: he\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -343,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/he/LC_MESSAGES/study.po
+++ b/priv/gettext/he/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: he\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,52 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/study.po
+++ b/priv/gettext/it/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: it\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,52 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/it/LC_MESSAGES/study.po
+++ b/priv/gettext/it/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: it\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -343,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/nl/LC_MESSAGES/study.po
+++ b/priv/gettext/nl/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: nl\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -343,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/nl/LC_MESSAGES/study.po
+++ b/priv/gettext/nl/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: nl\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,52 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/pt/LC_MESSAGES/study.po
+++ b/priv/gettext/pt/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: pt\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "A princípio, as setas mostrarão quais movimentos estão neste estudo. Depois de executar esses movimentos duas vezes, as setas não serão mais exibidas."
@@ -21,7 +21,7 @@ msgstr "A princípio, as setas mostrarão quais movimentos estão neste estudo. 
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "No final das linhas, o tabuleiro só é reiniciado após 3 segundos, dando-lhe tempo para rever a posição final."
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Capítulo"
@@ -31,34 +31,34 @@ msgstr "Capítulo"
 msgid "Chapter Selection"
 msgstr "Seleção de capítulo"
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Crie uma conta para obter todos os recursos do Listudy e carregue seus próprios estudos."
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Criador(a)"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descrição"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Você tem feedback, sugestões ou quer dizer algo legal? Comente sobre o estudo abaixo."
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Você gosta deste estudo? Compartilhe com seus amigos."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Editar"
@@ -68,7 +68,7 @@ msgstr "Editar"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Se você gostar deste estudo, certifique-se de adicioná-lo como favorito para que ele seja listado em Seus estudos"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Atraso nos movimentos de peças:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Abertura"
@@ -90,52 +90,52 @@ msgstr "Abertura"
 msgid "Play against Stockfish"
 msgstr "Jogue contra Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Lance correto!"
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Iniciar treinamento."
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Este lance não está no estudo, tente novamente."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Você aprendeu 100 movimentos hoje. Faça uma pausa ou volte amanhã para obter o efeito de treinamento completo."
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Você aprendeu 250 movimentos hoje. Para obter o melhor efeito de treinamento, volte amanhã. Ou não, estou apenas enviando uma mensagem e não sou um policial."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Você chegou ao fim desta linha."
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rápido"
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "Instantâneo"
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "médio"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "devagar"
@@ -342,7 +342,7 @@ msgstr "Mais novo"
 msgid "favorites"
 msgstr "favoritos"
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr "Tem certeza de que deseja excluir seu progresso de estudo?"
@@ -352,12 +352,12 @@ msgstr "Tem certeza de que deseja excluir seu progresso de estudo?"
 msgid "Progress"
 msgstr "Progresso"
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr "Reiniciar progresso"
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr "Progresso dos estudos"
@@ -367,42 +367,42 @@ msgstr "Progresso dos estudos"
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/pt/LC_MESSAGES/study.po
+++ b/priv/gettext/pt/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: pt\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "A princípio, as setas mostrarão quais movimentos estão neste estudo. Depois de executar esses movimentos duas vezes, as setas não serão mais exibidas."
@@ -21,7 +21,7 @@ msgstr "A princípio, as setas mostrarão quais movimentos estão neste estudo. 
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "No final das linhas, o tabuleiro só é reiniciado após 3 segundos, dando-lhe tempo para rever a posição final."
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Capítulo"
@@ -31,34 +31,34 @@ msgstr "Capítulo"
 msgid "Chapter Selection"
 msgstr "Seleção de capítulo"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Crie uma conta para obter todos os recursos do Listudy e carregue seus próprios estudos."
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Criador(a)"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descrição"
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Você tem feedback, sugestões ou quer dizer algo legal? Comente sobre o estudo abaixo."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Você gosta deste estudo? Compartilhe com seus amigos."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Editar"
@@ -68,7 +68,7 @@ msgstr "Editar"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Se você gostar deste estudo, certifique-se de adicioná-lo como favorito para que ele seja listado em Seus estudos"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Atraso nos movimentos de peças:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Abertura"
@@ -90,53 +90,52 @@ msgstr "Abertura"
 msgid "Play against Stockfish"
 msgstr "Jogue contra Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Lance correto!"
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Iniciar treinamento."
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Este lance não está no estudo, tente novamente."
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Você aprendeu 100 movimentos hoje. Faça uma pausa ou volte amanhã para obter o efeito de treinamento completo."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Você aprendeu 250 movimentos hoje. Para obter o melhor efeito de treinamento, volte amanhã. Ou não, estou apenas enviando uma mensagem e não sou um policial."
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Você chegou ao fim desta linha."
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "rápido"
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "Instantâneo"
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "médio"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "devagar"
@@ -343,7 +342,7 @@ msgstr "Mais novo"
 msgid "favorites"
 msgstr "favoritos"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr "Tem certeza de que deseja excluir seu progresso de estudo?"
@@ -353,12 +352,12 @@ msgstr "Tem certeza de que deseja excluir seu progresso de estudo?"
 msgid "Progress"
 msgstr "Progresso"
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr "Reiniciar progresso"
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr "Progresso dos estudos"
@@ -368,45 +367,42 @@ msgstr "Progresso dos estudos"
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/study.po
+++ b/priv/gettext/ru/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: ru\n"
 "Plural-Forms: nplurals=3\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,52 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/ru/LC_MESSAGES/study.po
+++ b/priv/gettext/ru/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: ru\n"
 "Plural-Forms: nplurals=3\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -21,7 +21,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -31,34 +31,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -90,53 +90,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -343,7 +342,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/study.pot
+++ b/priv/gettext/study.pot
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -20,7 +20,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -30,34 +30,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -78,7 +78,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -89,52 +89,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -351,12 +351,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -366,42 +366,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -426,17 +426,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -446,18 +446,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/study.pot
+++ b/priv/gettext/study.pot
@@ -10,7 +10,7 @@
 msgid ""
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr ""
@@ -20,7 +20,7 @@ msgstr ""
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr ""
@@ -30,34 +30,34 @@ msgstr ""
 msgid "Chapter Selection"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr ""
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr ""
@@ -78,7 +78,7 @@ msgid "Move delay:"
 msgstr ""
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr ""
@@ -89,53 +89,52 @@ msgstr ""
 msgid "Play against Stockfish"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr ""
@@ -342,7 +341,7 @@ msgstr ""
 msgid "favorites"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +351,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,45 +366,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -430,18 +426,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -451,7 +446,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/tr/LC_MESSAGES/study.po
+++ b/priv/gettext/tr/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: tr\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Başta, oklar size bu çalışmada hangi hamlelerin olduğunu gösterecek. Bu hamleleri iki kere oynadıktan sonra oklar bir daha gösterilmeyecek."
@@ -21,7 +21,7 @@ msgstr "Başta, oklar size bu çalışmada hangi hamlelerin olduğunu gösterece
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Hamle serilerinin sonunda son pozisyonu inceleyebilmeniz için tahta 3 saniye sonra sıfırlanır."
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Bölüm"
@@ -31,34 +31,34 @@ msgstr "Bölüm"
 msgid "Chapter Selection"
 msgstr "Bölüm Seçimi"
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Listudy sitesinin tüm özelliklerinden faydalanabilmek ve kendi çalışmalarınızı oluşturabilmek için kayıt olun."
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Oluşturan"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Açıklama"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Bir geri dönüşünüz, bir öneriniz veya söyleyecek güzel bir şeyiniz mi var? Aşağıya yorum yapın."
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Bu çalışmayı beğendiniz mi? Arkadaşlarınızla paylaşın."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Düzenle"
@@ -68,7 +68,7 @@ msgstr "Düzenle"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Bu çalışmayı beğendiyseniz favorileyin ve böylece Kendi Çalışmalarınız kısmında görün"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Hamle gecikmesi:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Açılış"
@@ -90,52 +90,52 @@ msgstr "Açılış"
 msgid "Play against Stockfish"
 msgstr "Stockfish'e karşı oyna"
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Doğru hamle!"
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Alıştırmaya başla."
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Bu hamle çalışmada yok, tekrar deneyin."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Bugün 100 hamle öğrendiniz. Alıştırmadan tam etkiyi almak için belki bir ara verin veya yarın devam edin."
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Bugün 250 hamle öğrendiniz. Alıştırmadan en iyi etkiyi almak için yarın devam edin. Veya etmeyin, ben sadece bir metinim, polis değil."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Bu hamle serisinin sonuna ulaştınız."
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "hızlı"
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "anında"
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "orta"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "yavaş"
@@ -342,7 +342,7 @@ msgstr "En yeni"
 msgid "favorites"
 msgstr "favoriler"
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -352,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -367,42 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""

--- a/priv/gettext/tr/LC_MESSAGES/study.po
+++ b/priv/gettext/tr/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: tr\n"
 "Plural-Forms: nplurals=2\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Başta, oklar size bu çalışmada hangi hamlelerin olduğunu gösterecek. Bu hamleleri iki kere oynadıktan sonra oklar bir daha gösterilmeyecek."
@@ -21,7 +21,7 @@ msgstr "Başta, oklar size bu çalışmada hangi hamlelerin olduğunu gösterece
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Hamle serilerinin sonunda son pozisyonu inceleyebilmeniz için tahta 3 saniye sonra sıfırlanır."
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Bölüm"
@@ -31,34 +31,34 @@ msgstr "Bölüm"
 msgid "Chapter Selection"
 msgstr "Bölüm Seçimi"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Listudy sitesinin tüm özelliklerinden faydalanabilmek ve kendi çalışmalarınızı oluşturabilmek için kayıt olun."
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Oluşturan"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Açıklama"
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Bir geri dönüşünüz, bir öneriniz veya söyleyecek güzel bir şeyiniz mi var? Aşağıya yorum yapın."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Bu çalışmayı beğendiniz mi? Arkadaşlarınızla paylaşın."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Düzenle"
@@ -68,7 +68,7 @@ msgstr "Düzenle"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Bu çalışmayı beğendiyseniz favorileyin ve böylece Kendi Çalışmalarınız kısmında görün"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Hamle gecikmesi:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Açılış"
@@ -90,53 +90,52 @@ msgstr "Açılış"
 msgid "Play against Stockfish"
 msgstr "Stockfish'e karşı oyna"
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "Doğru hamle!"
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Alıştırmaya başla."
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Bu hamle çalışmada yok, tekrar deneyin."
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Bugün 100 hamle öğrendiniz. Alıştırmadan tam etkiyi almak için belki bir ara verin veya yarın devam edin."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Bugün 250 hamle öğrendiniz. Alıştırmadan en iyi etkiyi almak için yarın devam edin. Veya etmeyin, ben sadece bir metinim, polis değil."
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Bu hamle serisinin sonuna ulaştınız."
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "hızlı"
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "anında"
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "orta"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "yavaş"
@@ -343,7 +342,7 @@ msgstr "En yeni"
 msgid "favorites"
 msgstr "favoriler"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr ""
@@ -353,12 +352,12 @@ msgstr ""
 msgid "Progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr ""
@@ -368,45 +367,42 @@ msgstr ""
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/study.po
+++ b/priv/gettext/vi/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: vi\n"
 "Plural-Forms: nplurals=1\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:125
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Lúc đầu, các mũi tên sẽ cho bạn thấy những động tác nào trong bài học này. Một khi bạn đã chơi các động tác này hai lần, các mũi tên không còn được hiển thị nữa."
@@ -21,7 +21,7 @@ msgstr "Lúc đầu, các mũi tên sẽ cho bạn thấy những động tác n
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Ở cuối dòng, bàn cờ chỉ được đặt lại sau 3 giây cho bạn thời gian để xem lại vị trí cuối cùng."
 
-#: lib/listudy_web/templates/study/show.html.eex:129
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Chương"
@@ -31,34 +31,34 @@ msgstr "Chương"
 msgid "Chapter Selection"
 msgstr "Lựa chọn chương"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Tạo một tài khoản để có được tất cả các tính năng của Listudy và tải lên các bài học của riêng bạn."
 
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:80
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Người tạo ra"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:66
+#: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Miêu tả"
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Bạn có phản hồi, đề xuất hay bạn muốn nói điều gì đó tốt đẹp? Bình luận về bài học dưới đây."
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Bạn có thích bài học này không? Chia sẻ nó với bạn bè của bạn."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:70
+#: lib/listudy_web/templates/study/show.html.eex:77
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Sửa"
@@ -68,7 +68,7 @@ msgstr "Sửa"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:130
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Nếu bạn thích bài học này, hãy chọn yêu thích nó để nó được liệt kê trong bài học của bạn"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Nước đi chậm:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:76
+#: lib/listudy_web/templates/study/show.html.eex:83
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Khai cuộc"
@@ -90,53 +90,52 @@ msgstr "Khai cuộc"
 msgid "Play against Stockfish"
 msgstr "Chơi chống lại Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:127
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "nước đi đúng!"
 
-#: lib/listudy_web/templates/study/show.html.eex:124
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Bắt đầu tập."
 
-#: lib/listudy_web/templates/study/show.html.eex:126
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Nước đi này không có trong bài học, hãy thử lại."
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Hôm nay bạn đã học được 100 nước đi. Có thể nghỉ ngơi hoặc trở lại vào ngày mai để có được hiệu quả tập luyện tốt."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Hôm nay bạn đã học được 250 nước đi. Để có hiệu quả tập luyện tốt nhất sẽ trở lại vào ngày mai. Hoặc không, tôi chỉ nhắn tin chứ không phải cảnh sát."
 
-#: lib/listudy_web/templates/study/show.html.eex:128
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Bạn đã đi đến cuối dòng này."
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "nhanh"
 
-#: lib/listudy_web/templates/study/show.html.eex:60
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "ngay"
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "vừa"
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "chậm"
@@ -343,7 +342,7 @@ msgstr "Mới nhất"
 msgid "favorites"
 msgstr "yêu thích"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr "Bạn có chắc chắn muốn xóa tiến trình học tập của bạn?"
@@ -353,12 +352,12 @@ msgstr "Bạn có chắc chắn muốn xóa tiến trình học tập của bạ
 msgid "Progress"
 msgstr "Tiến bộ"
 
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr "Đặt lại tiến độ"
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr "Tiến độ học tập"
@@ -368,45 +367,42 @@ msgstr "Tiến độ học tập"
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:48
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:54
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:57
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -431,18 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:51
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -452,7 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:64
+#: lib/listudy_web/templates/study/show.html.eex:160
+#, elixir-autogen, elixir-format
+msgid "Max depth: "
 msgstr ""

--- a/priv/gettext/vi/LC_MESSAGES/study.po
+++ b/priv/gettext/vi/LC_MESSAGES/study.po
@@ -11,7 +11,7 @@ msgstr ""
 "Language: vi\n"
 "Plural-Forms: nplurals=1\n"
 
-#: lib/listudy_web/templates/study/show.html.eex:132
+#: lib/listudy_web/templates/study/show.html.eex:131
 #, elixir-autogen, elixir-format
 msgid "At first the arrows will show you which moves are in this study. Once you have played these moves twice, the arrows are no longer shown."
 msgstr "Lúc đầu, các mũi tên sẽ cho bạn thấy những động tác nào trong bài học này. Một khi bạn đã chơi các động tác này hai lần, các mũi tên không còn được hiển thị nữa."
@@ -21,7 +21,7 @@ msgstr "Lúc đầu, các mũi tên sẽ cho bạn thấy những động tác n
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
 msgstr "Ở cuối dòng, bàn cờ chỉ được đặt lại sau 3 giây cho bạn thời gian để xem lại vị trí cuối cùng."
 
-#: lib/listudy_web/templates/study/show.html.eex:136
+#: lib/listudy_web/templates/study/show.html.eex:135
 #, elixir-autogen, elixir-format
 msgid "Chapter"
 msgstr "Chương"
@@ -31,34 +31,34 @@ msgstr "Chương"
 msgid "Chapter Selection"
 msgstr "Lựa chọn chương"
 
-#: lib/listudy_web/templates/study/show.html.eex:139
+#: lib/listudy_web/templates/study/show.html.eex:138
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
 msgstr "Tạo một tài khoản để có được tất cả các tính năng của Listudy và tải lên các bài học của riêng bạn."
 
-#: lib/listudy_web/templates/study/show.html.eex:80
+#: lib/listudy_web/templates/study/show.html.eex:79
 #, elixir-autogen, elixir-format
 msgid "Creator"
 msgstr "Người tạo ra"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
-#: lib/listudy_web/templates/study/show.html.eex:73
+#: lib/listudy_web/templates/study/show.html.eex:72
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Miêu tả"
 
-#: lib/listudy_web/templates/study/show.html.eex:140
+#: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
 msgstr "Bạn có phản hồi, đề xuất hay bạn muốn nói điều gì đó tốt đẹp? Bình luận về bài học dưới đây."
 
-#: lib/listudy_web/templates/study/show.html.eex:138
+#: lib/listudy_web/templates/study/show.html.eex:137
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
 msgstr "Bạn có thích bài học này không? Chia sẻ nó với bạn bè của bạn."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
-#: lib/listudy_web/templates/study/show.html.eex:77
+#: lib/listudy_web/templates/study/show.html.eex:76
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Sửa"
@@ -68,7 +68,7 @@ msgstr "Sửa"
 msgid "Favorite study"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:137
+#: lib/listudy_web/templates/study/show.html.eex:136
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
 msgstr "Nếu bạn thích bài học này, hãy chọn yêu thích nó để nó được liệt kê trong bài học của bạn"
@@ -79,7 +79,7 @@ msgid "Move delay:"
 msgstr "Nước đi chậm:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
-#: lib/listudy_web/templates/study/show.html.eex:83
+#: lib/listudy_web/templates/study/show.html.eex:82
 #, elixir-autogen, elixir-format
 msgid "Opening"
 msgstr "Khai cuộc"
@@ -90,52 +90,52 @@ msgstr "Khai cuộc"
 msgid "Play against Stockfish"
 msgstr "Chơi chống lại Stockfish"
 
-#: lib/listudy_web/templates/study/show.html.eex:134
+#: lib/listudy_web/templates/study/show.html.eex:133
 #, elixir-autogen, elixir-format
 msgid "Right move!"
 msgstr "nước đi đúng!"
 
-#: lib/listudy_web/templates/study/show.html.eex:131
+#: lib/listudy_web/templates/study/show.html.eex:130
 #, elixir-autogen, elixir-format
 msgid "Starting training."
 msgstr "Bắt đầu tập."
 
-#: lib/listudy_web/templates/study/show.html.eex:133
+#: lib/listudy_web/templates/study/show.html.eex:132
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
 msgstr "Nước đi này không có trong bài học, hãy thử lại."
 
-#: lib/listudy_web/templates/study/show.html.eex:141
+#: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
 msgstr "Hôm nay bạn đã học được 100 nước đi. Có thể nghỉ ngơi hoặc trở lại vào ngày mai để có được hiệu quả tập luyện tốt."
 
-#: lib/listudy_web/templates/study/show.html.eex:142
+#: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
 msgstr "Hôm nay bạn đã học được 250 nước đi. Để có hiệu quả tập luyện tốt nhất sẽ trở lại vào ngày mai. Hoặc không, tôi chỉ nhắn tin chứ không phải cảnh sát."
 
-#: lib/listudy_web/templates/study/show.html.eex:135
+#: lib/listudy_web/templates/study/show.html.eex:134
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
 msgstr "Bạn đã đi đến cuối dòng này."
 
-#: lib/listudy_web/templates/study/show.html.eex:152
+#: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "fast"
 msgstr "nhanh"
 
-#: lib/listudy_web/templates/study/show.html.eex:154
+#: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "instant"
 msgstr "ngay"
 
-#: lib/listudy_web/templates/study/show.html.eex:153
+#: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "medium"
 msgstr "vừa"
 
-#: lib/listudy_web/templates/study/show.html.eex:151
+#: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "slow"
 msgstr "chậm"
@@ -342,7 +342,7 @@ msgstr "Mới nhất"
 msgid "favorites"
 msgstr "yêu thích"
 
-#: lib/listudy_web/templates/study/show.html.eex:158
+#: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
 msgstr "Bạn có chắc chắn muốn xóa tiến trình học tập của bạn?"
@@ -352,12 +352,12 @@ msgstr "Bạn có chắc chắn muốn xóa tiến trình học tập của bạ
 msgid "Progress"
 msgstr "Tiến bộ"
 
-#: lib/listudy_web/templates/study/show.html.eex:168
+#: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
 msgstr "Đặt lại tiến độ"
 
-#: lib/listudy_web/templates/study/show.html.eex:166
+#: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
 msgstr "Tiến độ học tập"
@@ -367,42 +367,42 @@ msgstr "Tiến độ học tập"
 msgid "Analyze this position with the Lichess Analysis Board"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:145
+#: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Arrows: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:146
+#: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "Arrows: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:143
+#: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 2x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:144
+#: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "Arrows: until played 5x"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:148
+#: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:147
+#: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:150
+#: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:149
+#: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
 msgstr ""
@@ -427,17 +427,17 @@ msgstr ""
 msgid "Analyze position"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:159
+#: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "response"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:156
+#: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:155
+#: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Comments: when arrows show"
 msgstr ""
@@ -447,18 +447,18 @@ msgstr ""
 msgid "Option to control when comments are displayed"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:157
+#: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
 msgstr ""
 
-#: lib/listudy_web/templates/study/show.html.eex:63
-#, elixir-autogen, elixir-format
-msgid "Limits the number of moves that it is played. One move is when both white and black has moved something on the board."
-msgstr ""
-
 #: lib/listudy_web/templates/study/show.html.eex:64
-#: lib/listudy_web/templates/study/show.html.eex:160
+#: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
+msgstr ""
+
+#: lib/listudy_web/templates/study/show.html.eex:63
+#, elixir-autogen, elixir-format
+msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
 msgstr ""


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41130048/204940349-c8580ba8-bacd-497b-a979-7960f2a45f9e.png)

Here is another option, to control the max depth.

I added both a range input control and a number and a + and a - next to it. I felt it made it much clearer what the range was for. The max depth chosen is saved in local storage per study id and chapter index. And if any of the options are lost it reverts to defaults. Same if the repertoire should happen to be smaller than the saved value, which I am not sure could happen.

What do you think? You didn't say anything about the screenshot in the last PR so I figured you'd be ok with this one.

-----------

Also, next, maybe the final thing :) I am working on is reading user created arrows and circles from the study and displaying them. As you might be aware a user can create these themselves and choose among these four colors, at least on Lichess. And I think ChessTempo and ChessBase follows the same format for storing these in the PGN. Of course, there would have to be some way to decide whether to show these user created arrows vs the auto-generated once based on upcoming possible moves. Maybe an option, haven't tried that yet. But, just to give you a heads up, and give you the opportunity to come with suggestions if you have any, or object if you don't like it. 

![image](https://user-images.githubusercontent.com/41130048/204940585-56c69112-9fe7-4966-b768-85b7cdb89673.png)

On the picture above the e2e4 arrow is an autogenerated one because that move is in the repertoire. I experimented with changing the color of these two a grayscale but I don't know. Also, whenever there is a user generated arrow between the exact same squares that there is a move on, I think you would want the user generated arrow to take precedence, if you were even combining both in the same view. The option could be, 1) user arrows, 2) auto arrows, 3) user + auto arrows. Maybe even rename the existing arrows option into "hints" instead. Just some ideas that have gone through my head.