### PR TITLE
Fixing flexbox issues with large comments

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -64,8 +64,21 @@ body {
 }
 
 .infoBox {
+    position: relative;
     margin: 10px 0px;
     padding:12px;
+}
+
+.close_button {
+    display: inline-block;
+	position: absolute;
+	top: -5px;
+	right: 1px;
+    cursor: pointer;
+    /* Make it non-selectable */
+    -webkit-user-select: none; /* Safari */
+    -ms-user-select: none; /* IE 10 and IE 11 */
+    user-select: none; /* Standard syntax */
 }
 
 .hidden {
@@ -137,6 +150,7 @@ body {
 .with_sidebar {
     display: flex;
 }
+
 @media only screen and (max-width: 600px) {
     .with_sidebar {
         display: block;
@@ -145,17 +159,6 @@ body {
         margin-left: 0px !important;
         
     }
-    .study_options {
-        position: relative !important;
-    }
-    .chapter_selection {
-        max-width: 100% !important;
-    }
-}
-.study_options {
-    position: absolute;
-    bottom: 0;
-    left: 0;
 }
 
 .sidebar_main {

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -71,9 +71,9 @@ body {
 
 .close_button {
     display: inline-block;
-	position: absolute;
-	top: -5px;
-	right: 1px;
+    position: absolute;
+    top: -5px;
+    right: 1px;
     cursor: pointer;
     /* Make it non-selectable */
     -webkit-user-select: none; /* Safari */
@@ -116,17 +116,17 @@ input:invalid {
 
 blockquote:before {
     font-family: "listudy";
-	font-size: 32px;
-	color: var(--font-color);
-	content: "&";
-	display: block;
-	position: absolute;
-	top: -15px;
-	left: 0;
-	transform: scaleX(-1);
+    font-size: 32px;
+    color: var(--font-color);
+    content: "&";
+    display: block;
+    position: absolute;
+    top: -15px;
+    left: 0;
+    transform: scaleX(-1);
 }
 blockquote {
-	font-size: 1.1em;
+    font-size: 1.1em;
     margin: 0 0 27px;
     padding-left: 48px;
     position: relative;

--- a/assets/css/features/study.css
+++ b/assets/css/features/study.css
@@ -5,9 +5,6 @@
 }
 
 @media only screen and (max-width: 600px) {
-    .study_options_right {
-        position: relative !important;
-    }
     .chapter_selection {
         max-width: 100% !important;
     }
@@ -19,6 +16,7 @@
         min-height:100%;
         overflow-x: hidden;
         margin-bottom: 2em;
+        padding-right: 0.5em;
     }
 }
 
@@ -26,27 +24,13 @@
     margin-bottom: 2em;
 }
 
-@media only screen and (min-width: 600px) {
-    .area_below_main {
-        display: flex;
-        flex-direction: row;
-    }
-}
-
 .chapter_selection {
-    flex: 0;
     margin-right: 2em;
-    max-width: 250px;
+    max-width: 230px;
 }
 
 .study_favorite_form {
     margin-bottom: 0;
-}
-
-.study_options_right {
-    display: inline-block;
-    flex: 0;
-    margin-bottom: 2rem;
 }
 
 @media only screen and (max-width: 600px) {
@@ -55,16 +39,8 @@
     }
 }
 
-.study_options_left {
-    flex: 2;
-    margin-bottom: 2rem;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-}
-
 @media only screen and (max-width: 600px) {
-    .study_options_left {
+    .options_area {
         padding: 1em;
         display: flex;
         flex-direction: column;
@@ -80,13 +56,23 @@
     margin: -1.5em -1.5em -1em 0em;
 }
 
-.study_option_item_below {
+.options_area {
+    flex: 2;
+    margin-bottom: 1.5rem;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+.option_item {
     margin-right: 3rem;
     min-width: 26ch;
 }
 
-.study_option_item_below > a {
-	display: block;
+.option_item_progressbar {
+    margin-right: 3rem;
+    margin-bottom: 1em;
+    width: 55ch;
 }
 
 .select2 {

--- a/assets/css/features/study.css
+++ b/assets/css/features/study.css
@@ -4,16 +4,48 @@
     padding: 0.5em;
 }
 
+@media only screen and (max-width: 600px) {
+    .study_options_right {
+        position: relative !important;
+    }
+    .chapter_selection {
+        max-width: 100% !important;
+    }
+}
+
+@media only screen and (min-width: 600px) {
+    .sidebar_innercontainer {
+        height:0;
+        min-height:100%;
+        overflow-x: hidden;
+        margin-bottom: 2em;
+    }
+}
+
+#study_mainpage1 {
+    margin-bottom: 2em;
+}
+
+@media only screen and (min-width: 600px) {
+    .area_below_main {
+        display: flex;
+        flex-direction: row;
+    }
+}
+
 .chapter_selection {
-    margin-top: 0.5em;
-    max-width: 230px;
+    flex: 0;
+    margin-right: 2em;
+    max-width: 250px;
 }
 
 .study_favorite_form {
     margin-bottom: 0;
 }
 
-.study_options {
+.study_options_right {
+    display: inline-block;
+    flex: 0;
     margin-bottom: 2rem;
 }
 
@@ -23,7 +55,8 @@
     }
 }
 
-.study_options_below {
+.study_options_left {
+    flex: 2;
     margin-bottom: 2rem;
     display: flex;
     flex-direction: row;
@@ -31,7 +64,7 @@
 }
 
 @media only screen and (max-width: 600px) {
-    .study_options_below {
+    .study_options_left {
         padding: 1em;
         display: flex;
         flex-direction: column;
@@ -49,7 +82,7 @@
 
 .study_option_item_below {
     margin-right: 3rem;
-    min-width: 24ch;
+    min-width: 26ch;
 }
 
 .study_option_item_below > a {
@@ -62,11 +95,6 @@
 
 .study_below_highlight {
     margin-top: 1.5rem;
-}
-
-.study_comments {
-    overflow-y: auto;
-    max-height: 20em;
 }
 
 .study_comments > div {

--- a/assets/js/modules/info_boxes.js
+++ b/assets/js/modules/info_boxes.js
@@ -12,6 +12,7 @@ function clear_all_text() {
 
 function set_text(id, text, extra = { bold_text: "", symbol: "" }) {
     let div = document.getElementById(id);
+
     let prefix_symbol = "";
     if (div == null) {
         return;
@@ -36,6 +37,12 @@ function set_text(id, text, extra = { bold_text: "", symbol: "" }) {
         }
     } else {
         div.classList.add("hidden");
+    }
+
+    // Button to close the info box
+    let div_close = div.querySelector(".close_button");
+    if (div_close != undefined) {
+        div_close.onclick = () => { div.classList.add("hidden") }
     }
 
     // This function can (and will be) be called with untrusted 

--- a/lib/listudy_web/templates/component/infoboxes.html.eex
+++ b/lib/listudy_web/templates/component/infoboxes.html.eex
@@ -1,5 +1,6 @@
 <div class="success">
   <p id="success" class="infoBox hidden">
+    <span id="close_button" class="close_button" role="button">🞫</span>
     <span id="success_symbol"><%= Map.get(assigns, :success_symbol, "") %></span>
     <b id="success_bold"><%= Map.get(assigns, :success_bold, "") %></b>
     <span id="success_text"><%= Map.get(assigns, :success_text, "") %></span>
@@ -7,6 +8,7 @@
 </div>
 <div class="info">
   <p id="info" class="infoBox hidden">
+    <span id="close_button" class="close_button" role="button">🞫</span>
     <span id="info_symbol"><%= Map.get(assigns, :info_symbol, "") %></span>
     <b id="info_bold"><%= Map.get(assigns, :info_bold, "") %></b>
     <span id="info_text"><%= Map.get(assigns, :info_text, "") %></span>
@@ -14,6 +16,7 @@
 </div>
 <div class="error">
   <p id="error" class="infoBox hidden">
+    <span id="close_button" class="close_button" role="button">🞫</span>
     <span id="error_symbol"><%= Map.get(assigns, :error_symbol, "") %></span>
     <b id="error_bold"><%= Map.get(assigns, :error_bold, "") %></b>
     <span id="error_text"><%= Map.get(assigns, :error_text, "") %></span>
@@ -21,6 +24,7 @@
 </div>
 <div class="info">
   <p id="suggestion" class="infoBox hidden">
+    <span id="close_button" class="close_button" role="button">🞫</span>
     <span id="suggestion_symbol"><%= Map.get(assigns, :suggestion_symbol, "") %></span>
     <b id="suggestion_bold"><%= Map.get(assigns, :suggestion_bold, "") %></b>
     <span id="suggestion_text"><%= Map.get(assigns, :suggestion_text, "") %></span>

--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -18,59 +18,61 @@
     </div>
   </div>
 </div>
-<div class="area_below_main">
-  <div class="study_options_left">
-    <div class="study_option_item_below">
-      <a class="icon" data-icon="!" id="play_stockfish" href="<%= Routes.page_path(@conn, :play_stockfish, @locale) %>#rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" title="<%= dgettext "study", "Play against Stockfish" %>"><%= dgettext "study", "Play against Stockfish" %></a>
-    </div>
-    <div class="study_option_item_below">
-      <a class="icon" data-icon="/" id="analysis_board" href="https://lichess.org/analysis"
-      title="<%= dgettext "study", "Analyze this position with the Lichess Analysis Board" %>"><%= dgettext "study", "Analyze position" %></a>
-    </div>
-    <div class="study_option_item_below">
-      <%= if !@study.favorites do %>
-        <%= link dgettext("study", "Favorite study"), to: Routes.study_path(@conn, :favorite_study, @study.slug), method: :post, class: "icon", "data-icon": "#" %>
-      <% else %>
-        <%= link dgettext("study" ,"Unfavorite study"), to: Routes.study_path(@conn, :unfavorite_study, @study.slug), method: :post, class: "icon", "data-icon": '"' %>
-      <% end %>
-    </div>
-    <div class="study_option_item_below">
-      <a class="icon" data-icon="." id="reset_line"><%= dgettext("study", "Reset line") %></a>
-    </div>
-    <div class="study_option_item_below">
-      <a class="icon" data-icon="-" id="arrows_toggle">placeholder</a>
-    </div>
-    <div class="study_option_item_below">
-      <a class="icon" data-icon="3" id="comments_toggle" title="<%= dgettext("study", "Option to control when comments are displayed") %>">placeholder</a>
-    </div>
-    <div class="study_option_item_below">
-      <a class="icon" data-icon="(" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>">placeholder</a>
-    </div>
-    <div class="study_option_item_below">
-      <a class="icon" data-icon="$" id="key_move" title="<%= dgettext("study", "Don't repeat the early moves that are already known. Skips to the first branching move in the study.") %>">placeholder</a>
-    </div>
-    <div class="study_option_item_below">
-      <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time">placeholder</span></a>
-    </div>
-    <div class="study_option_item_below">
-      <div id="max_depth_container" title="<%= dgettext("study", "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire.") %>">
-        <a class="icon" data-icon="+"><%= dgettext("study", "Max depth: ") %></a>
-        <a id="max_depth_label" class="max_depth_label">placeholder</a>
-        <a id="max_depth_sub" class="max_depth_ctrl" role="button">-</a><input type="range" id="max_depth_range" class="max_depth_range" min="1" max="1"><a id="max_depth_add" class="max_depth_ctrl" role="button">+</a>
-      </div>
+<div class="options_area">
+  <div class="option_item">
+    <a class="icon" data-icon="!" id="play_stockfish" href="<%= Routes.page_path(@conn, :play_stockfish, @locale) %>#rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" title="<%= dgettext "study", "Play against Stockfish" %>"><%= dgettext "study", "Play against Stockfish" %></a>
+  </div>
+  <div class="option_item">
+    <a class="icon" data-icon="/" id="analysis_board" href="https://lichess.org/analysis"
+    title="<%= dgettext "study", "Analyze this position with the Lichess Analysis Board" %>"><%= dgettext "study", "Analyze position" %></a>
+  </div>
+  <div class="option_item">
+    <a class="icon" data-icon="." id="reset_line"><%= dgettext("study", "Reset line") %></a>
+  </div>
+  <div class="option_item">
+    <%= if !@study.favorites do %>
+      <%= link dgettext("study", "Favorite study"), to: Routes.study_path(@conn, :favorite_study, @study.slug), method: :post, class: "icon", "data-icon": "#" %>
+    <% else %>
+      <%= link dgettext("study" ,"Unfavorite study"), to: Routes.study_path(@conn, :unfavorite_study, @study.slug), method: :post, class: "icon", "data-icon": '"' %>
+    <% end %>
+  </div>
+  <div class="option_item">
+    <a class="icon" data-icon="-" id="arrows_toggle">placeholder</a>
+  </div>
+  <div class="option_item">
+    <a class="icon" data-icon="3" id="comments_toggle" title="<%= dgettext("study", "Option to control when comments are displayed") %>">placeholder</a>
+  </div>
+  <div class="option_item">
+    <a class="icon" data-icon="(" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>">placeholder</a>
+  </div>
+  <div class="option_item">
+    <a class="icon" data-icon="$" id="key_move" title="<%= dgettext("study", "Don't repeat the early moves that are already known. Skips to the first branching move in the study.") %>">placeholder</a>
+  </div>
+  <div class="option_item">
+    <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time">placeholder</span></a>
+  </div>
+  <div class="option_item">
+    <div id="max_depth_container" title="<%= dgettext("study", "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire.") %>">
+      <a class="icon" data-icon="+"><%= dgettext("study", "Max depth: ") %></a>
+      <a id="max_depth_label" class="max_depth_label">placeholder</a>
+      <a id="max_depth_sub" class="max_depth_ctrl" role="button">-</a><input type="range" id="max_depth_range" class="max_depth_range" min="1" max="1"><a id="max_depth_add" class="max_depth_ctrl" role="button">+</a>
     </div>
   </div>
+</div>
 
-  <div class="study_options_right">
-    <div class="chapter_selection sidebar_padded">
+<div class="options_area">
+  <div class="option_item_progressbar">
+    <a style="padding-bottom: 5px;" href="#" data-icon="+" class="icon modal_open" id="progress"><%= dgettext("study","Progress") %></a>
+    <div id="chapter_progress"></div>
+  </div>
+  <div class="option_item">
+    <div class="chapter_selection">
       <label for="chapter_select"><%= dgettext "study", "Chapter Selection" %></label>
       <select id="chapter_select"></select>
-      <div id="chapter_progress"></div>
-      <a href="#" data-icon="+" class="icon modal_open" id="progress"><%= dgettext("study","Progress") %></a>
     </div>
   </div>
-
 </div>
+
 
 <div class="highlight">
   <b><%= dgettext "study", "Description" %></b>

--- a/lib/listudy_web/templates/study/show.html.eex
+++ b/lib/listudy_web/templates/study/show.html.eex
@@ -4,8 +4,8 @@
   <div id="game_container" class="sidebar_main">
     <%= render ListudyWeb.ComponentView, "chessground.html" %>
   </div>
-  <div class="sidebar">
-    <div>
+  <div class="sidebar" id="study_mainpage1">
+    <div class="sidebar_innercontainer">
       <%= render ListudyWeb.ComponentView, "infoboxes.html" %>
 
       <div class="sidebar_padded">
@@ -16,56 +16,60 @@
         <div id="comments" class="study_comments"></div>
       </div>
     </div>
-    <div class="study_options">
-      <div class="chapter_selection sidebar_padded">
-        <label for="chapter_select"><%= dgettext "study", "Chapter Selection" %></label>
-        <select id="chapter_select"></select>
-        <div id="chapter_progress"></div>
-        <a href="#" data-icon="+" class="icon modal_open" id="progress"><%= dgettext("study","Progress") %></a>
+  </div>
+</div>
+<div class="area_below_main">
+  <div class="study_options_left">
+    <div class="study_option_item_below">
+      <a class="icon" data-icon="!" id="play_stockfish" href="<%= Routes.page_path(@conn, :play_stockfish, @locale) %>#rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" title="<%= dgettext "study", "Play against Stockfish" %>"><%= dgettext "study", "Play against Stockfish" %></a>
+    </div>
+    <div class="study_option_item_below">
+      <a class="icon" data-icon="/" id="analysis_board" href="https://lichess.org/analysis"
+      title="<%= dgettext "study", "Analyze this position with the Lichess Analysis Board" %>"><%= dgettext "study", "Analyze position" %></a>
+    </div>
+    <div class="study_option_item_below">
+      <%= if !@study.favorites do %>
+        <%= link dgettext("study", "Favorite study"), to: Routes.study_path(@conn, :favorite_study, @study.slug), method: :post, class: "icon", "data-icon": "#" %>
+      <% else %>
+        <%= link dgettext("study" ,"Unfavorite study"), to: Routes.study_path(@conn, :unfavorite_study, @study.slug), method: :post, class: "icon", "data-icon": '"' %>
+      <% end %>
+    </div>
+    <div class="study_option_item_below">
+      <a class="icon" data-icon="." id="reset_line"><%= dgettext("study", "Reset line") %></a>
+    </div>
+    <div class="study_option_item_below">
+      <a class="icon" data-icon="-" id="arrows_toggle">placeholder</a>
+    </div>
+    <div class="study_option_item_below">
+      <a class="icon" data-icon="3" id="comments_toggle" title="<%= dgettext("study", "Option to control when comments are displayed") %>">placeholder</a>
+    </div>
+    <div class="study_option_item_below">
+      <a class="icon" data-icon="(" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>">placeholder</a>
+    </div>
+    <div class="study_option_item_below">
+      <a class="icon" data-icon="$" id="key_move" title="<%= dgettext("study", "Don't repeat the early moves that are already known. Skips to the first branching move in the study.") %>">placeholder</a>
+    </div>
+    <div class="study_option_item_below">
+      <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time">placeholder</span></a>
+    </div>
+    <div class="study_option_item_below">
+      <div id="max_depth_container" title="<%= dgettext("study", "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire.") %>">
+        <a class="icon" data-icon="+"><%= dgettext("study", "Max depth: ") %></a>
+        <a id="max_depth_label" class="max_depth_label">placeholder</a>
+        <a id="max_depth_sub" class="max_depth_ctrl" role="button">-</a><input type="range" id="max_depth_range" class="max_depth_range" min="1" max="1"><a id="max_depth_add" class="max_depth_ctrl" role="button">+</a>
       </div>
     </div>
   </div>
-</div>
-<div class="study_options_below">
-  <div class="study_option_item_below">
-    <a class="icon" data-icon="!" id="play_stockfish" href="<%= Routes.page_path(@conn, :play_stockfish, @locale) %>#rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" title="<%= dgettext "study", "Play against Stockfish" %>"><%= dgettext "study", "Play against Stockfish" %></a>
-  </div>
-  <div class="study_option_item_below">
-    <a class="icon" data-icon="/" id="analysis_board" href="https://lichess.org/analysis"
-    title="<%= dgettext "study", "Analyze this position with the Lichess Analysis Board" %>"><%= dgettext "study", "Analyze position" %></a>
-  </div>
-  <div class="study_option_item_below">
-    <a class="icon" data-icon="." id="reset_line"><%= dgettext("study", "Reset line") %></a>
-  </div>
-  <div class="study_option_item_below">
-    <%= if !@study.favorites do %>
-      <%= link dgettext("study", "Favorite study"), to: Routes.study_path(@conn, :favorite_study, @study.slug), method: :post, class: "icon", "data-icon": "#" %>
-    <% else %>
-      <%= link dgettext("study" ,"Unfavorite study"), to: Routes.study_path(@conn, :unfavorite_study, @study.slug), method: :post, class: "icon", "data-icon": '"' %>
-    <% end %>
-  </div>
-  <div class="study_option_item_below">
-    <a class="icon" data-icon="-" id="arrows_toggle">placeholder</a>
-  </div>
-  <div class="study_option_item_below">
-    <a class="icon" data-icon="3" id="comments_toggle" title="<%= dgettext("study", "Option to control when comments are displayed") %>">placeholder</a>
-  </div>
-  <div class="study_option_item_below">
-    <a class="icon" data-icon="(" id="line_review" title="<%= dgettext("study", "At the end of lines the board is only reset after 3 seconds giving you time to review the final position.") %>">placeholder</a>
-  </div>
-  <div class="study_option_item_below">
-    <a class="icon" data-icon="$" id="key_move" title="<%= dgettext("study", "Don't repeat the early moves that are already known. Skips to the first branching move in the study.") %>">placeholder</a>
-  </div>
-  <div class="study_option_item_below">
-    <a class="icon" data-icon="(" id="move_delay"><%= dgettext("study", "Move delay:") %> <span id="move_delay_time">placeholder</span></a>
-  </div>
-  <div class="study_option_item_below">
-    <div id="max_depth_container" title="<%= dgettext("study", "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire.") %>">
-      <a class="icon" data-icon="+"><%= dgettext("study", "Max depth: ") %></a>
-      <a id="max_depth_label" class="max_depth_label">placeholder</a>
-      <a id="max_depth_sub" class="max_depth_ctrl" role="button">-</a><input type="range" id="max_depth_range" class="max_depth_range" min="1" max="1"><a id="max_depth_add" class="max_depth_ctrl" role="button">+</a>
+
+  <div class="study_options_right">
+    <div class="chapter_selection sidebar_padded">
+      <label for="chapter_select"><%= dgettext "study", "Chapter Selection" %></label>
+      <select id="chapter_select"></select>
+      <div id="chapter_progress"></div>
+      <a href="#" data-icon="+" class="icon modal_open" id="progress"><%= dgettext("study","Progress") %></a>
     </div>
   </div>
+
 </div>
 
 <div class="highlight">


### PR DESCRIPTION
I had a go at fixing the flexbox issues with large comments where they sort of overlayed the chapter selection before. 

**OLD:**
![image](https://user-images.githubusercontent.com/41130048/206902927-9d6ca32c-9e40-449c-b517-4bb4d1f87e52.png)

**NEW:**
![image](https://user-images.githubusercontent.com/41130048/206903055-dff73d31-ed68-4c8c-b286-5ef14ddab899.png)

**Also a video:**
https://user-images.githubusercontent.com/41130048/206902948-6e5d03b0-9b7f-4d89-a8eb-18802a8e1661.mp4

**Note!** I fixed the issue with the horizontal scrollbar by the way after recording the video.

Changes:
- Moved chapter selection to below the board, on the right side.
- Made a scrollbar appear that covers the whole right area.
- Removed the old scrollbars for mobile which made it really hard to scroll sometimes on mobile.
- Made the comment section never extend higher than the board itself.
- Changed the options from 3 columns to 2 columns.
- Added close button (x) to the info boxes.
- Made sure the Reset line option ends up in the right column.
- I moved some options from app.scss to study.css which were only local to studies.