### PR TITLE
Fix for Issue 140: Ignoring any localstorage exceptions to work without localstorage support

### DIFF
--- a/assets/js/study.js
+++ b/assets/js/study.js
@@ -454,7 +454,11 @@ function start_training() {
  */
 function store_trees() {
     let tree_key = study_id + "_tree";
-    localStorage.setItem(tree_key, JSON.stringify(trees));
+    try {
+        localStorage.setItem(tree_key, JSON.stringify(trees));
+    } catch(caught_error) {
+        console.log("Ignored localstorage error: " + caught_error);
+    }
 }
 
 // load the trees from the localStorage or generate if they dont exist
@@ -474,8 +478,6 @@ function setup_trees() {
             annotate_pgn(parsedpgn);
             trees = generate_move_trees(parsedpgn);
             clear_local_storage();
-            localStorage.setItem(hash_key, curr_hash);
-            localStorage.setItem(tree_key, JSON.stringify(trees));
         } catch(caught_error) {
             console.log(caught_error);
             let error_text = caught_error.name + " at line: " + caught_error.location.start.line +
@@ -483,6 +485,13 @@ function setup_trees() {
                              caught_error.found + "\"";
             set_text(error_div, error_text);
         }
+        try {
+            localStorage.setItem(tree_key, JSON.stringify(trees));
+            localStorage.setItem(hash_key, curr_hash);
+        } catch(caught_error) {
+            console.log("Ignored localstorage error: " + caught_error);
+        }
+
     } else {
         trees = JSON.parse(localStorage.getItem(tree_key));
     }


### PR DESCRIPTION
Ignoring any localstorage exceptions to work without localstorage support when when a study is too large to fit within the localstorage quota limit.

This fixes https://github.com/ArneVogel/listudy/issues/140

The problem was two-fold. As can be seen in the discussion of issue 140, IndeedLad probably experienced a Quota Exceeded exception when storing the tree in localstorage. But then in the catch-statement there was another error generated because caught_error.location was undefined for this particular exception resulting in a "Cannot read properties of undefined (reading 'start') at setup_trees (study.js:481:87)".

Just removing the location.start.line didn't help, and is not something you want to remove. Instead, I propose solving this by enclosing the writing of the tree and the hash to the localstorage in a separate try-catch and ignore any errors. By placing the storing of the hash last, in case of any problem with writing the tree, no hash is written. The app still works, though it needs to re-generate the tree next time. But, this doesn't seem to incur hardly any cost so I think this should be a workable solution that keeps the trees in localstorage for better performance, but when it doesn't fit it just continues to work without localstorage.

I am only ignoring writing to localstorage for this particular case as I think it's only really relevant here. It might be possible to look over how things are stored in the whole app, but I think this should be a cheap solution for now to make IndeedLads and other's large studies work.
