### PR TITLE
Improve Italian translations

### DIFF
--- a/priv/gettext/it/LC_MESSAGES/achievements.po
+++ b/priv/gettext/it/LC_MESSAGES/achievements.po
@@ -19,4 +19,4 @@ msgstr "Traguardi"
 #, elixir-format
 #: lib/listudy_web/templates/page/achievements.html.eex:2
 msgid "Can you get all achievements?"
-msgstr "Riesci a raggiungere tutti i traguardi?"
+msgstr "Sei in grado di raggiungere tutti i traguardi?"

--- a/priv/gettext/it/LC_MESSAGES/blind-tactics.po
+++ b/priv/gettext/it/LC_MESSAGES/blind-tactics.po
@@ -14,7 +14,7 @@ msgstr ""
 #, elixir-format
 #: tactics.html.eex:45
 msgid "As soon as you have solved the tactic, the final position is displayed. Did you have the same position in your head?"
-msgstr "Non appena hai risolto la tattica, viene visualizzata la posizione finale. Avevi la stessa posizione a mente?"
+msgstr "Non appena hai risolto la tattica, viene visualizzata la posizione finale. Avevi in mente la stessa posizione?"
 
 #, elixir-format
 #: tactics.html.eex:19
@@ -24,12 +24,12 @@ msgstr "Scacchiera congelata"
 #, elixir-format
 #: tactics.html.eex:21
 msgid "If you click on the position where a piece is positioned you will be shown the possible legal moves. If you then click again on the correct square, the move will be executed and the exercise will continue."
-msgstr "Se clicchi sulla posizione in cui si trova il pezzo ti verranno mostrate le possibili mosse legali. Se fai clic sulla casa corretta, la mossa verrà eseguita e l'esercizio continuerà."
+msgstr "Se fai clic sulla posizione in cui si trova un pezzo, ti verranno mostrate le possibili mosse legali. Se poi fai clic sulla casa corretta, la mossa verrà eseguita e l'esercizio continuerà."
 
 #, elixir-format
 #: tactics.html.eex:36
 msgid "Next to the board you will see the list of moves that have been played since the board was frozen. This list shows the current state of the game and the moves the opponent played."
-msgstr "Di fianco alla scacchiera vedrai la lista delle mosse che sono state giocate da quando la scacchiera è stata congelata. La lista mostra lo stato attuale della partita e le mosse giocate dall'avversario."
+msgstr "Accanto alla scacchiera vedrai la lista delle mosse che sono state giocate da quando la scacchiera è stata congelata. Questa lista mostra lo stato attuale della partita e le mosse giocate dall'avversario."
 
 #, elixir-format
 #: tactics.html.eex:43
@@ -39,7 +39,7 @@ msgstr "Tattiche"
 #, elixir-format
 #: tactics.html.eex:20
 msgid "The board is frozen and does not show the current state of the game. This means you do not see the latest state of the board. The pieces are not animated during the tactics. You have to keep the positions of the pieces in your head!"
-msgstr "La scacchiera è congelata e non mostra lo stato attuale della partita. Ciò significa che non vedi lo stato più recente della scacchiera. I pezzi non sono animati durante le tattiche. Devi mantenere le posizioni dei pezzi a mente!"
+msgstr "La scacchiera è congelata e non mostra lo stato attuale della partita. Ciò significa che non vedi lo stato più recente della scacchiera. I pezzi non sono animati durante le tattiche. Devi tenere a mente le posizioni dei pezzi!"
 
 #, elixir-format
 #: tactics.html.eex:35
@@ -54,7 +54,7 @@ msgstr "Le mosse eseguite dall'avversario durante le tattiche vengono aggiunte a
 #, elixir-format
 #: tactics.html.eex:8
 msgid "Use blind tactics to improve your chess visualisation skills. Solve tactics while seeing the board state of several moves from the past. You are given the representation of the board and the moves that have been made since then, and then you then have to solve the tactical problem by imagining the board and the moves played in your head."
-msgstr "Usa tattiche alla cieca per migliorare le tue abilità di visualizzazione degli scacchi. Risolvi le tattiche osservando lo stato della scacchiera diverse mosse del passato. Ti viene data la rappresentazione della scacchiera e le mosse che sono state fatte da allora, poi devi risolvere la tattica immaginando la scacchiera e le mosse giocate nella tua mente."
+msgstr "Usa le tattiche alla cieca per migliorare le tue abilità di visualizzazione. Risolvi le tattiche osservando lo stato della scacchiera di diverse mosse nel passato. Ti viene data la rappresentazione della scacchiera e le mosse che sono state fatte da allora, poi devi risolvere la tattica a mente, immaginando la scacchiera e le mosse giocate."
 
 #, elixir-format
 #: tactics.html.eex:15
@@ -64,12 +64,12 @@ msgstr "Usare le tattiche alla cieca richiede tempo per abituarsi. Qui cerco di 
 #, elixir-format
 #: tactics.html.eex:44
 msgid "Your task is to solve the exercise like with normal tactics. There is only one continuation that is correct."
-msgstr "Il tuo obbiettivo è quello di risolvere l'esercizio come le tattiche normali. C'è solo una continuazione che è corretta."
+msgstr "Il tuo compito è quello di risolvere l'esercizio come le tattiche normali. C'è solo una continuazione corretta."
 
 #, elixir-format
 #: tactics.html.eex:25
 msgid "different board state"
-msgstr "diverso stato della scacchiera"
+msgstr "stato diverso della scacchiera"
 
 #, elixir-format
 #: tactics.html.eex:32
@@ -79,7 +79,7 @@ msgstr "lista delle mosse"
 #, elixir-format
 #: tactics.html.eex:49
 msgid "solved tactic"
-msgstr "tattiche risolte"
+msgstr "tattica risolta"
 
 #, elixir-format
 #: tactics.html.eex:3
@@ -94,9 +94,9 @@ msgstr "Come funziona"
 #, elixir-format
 #: tactics.html.eex:4
 msgid "Improve your chess visualization skills"
-msgstr "Migliora le tue abilità di visualizzazione"
+msgstr "Migliora le tue capacità di visualizzazione"
 
 #, elixir-format
 #: tactics.html.eex:11
 msgid "Play Now!"
-msgstr "Giova Ora!"
+msgstr "Gioca Ora!"

--- a/priv/gettext/it/LC_MESSAGES/book.po
+++ b/priv/gettext/it/LC_MESSAGES/book.po
@@ -15,100 +15,100 @@ msgstr ""
 #: lib/listudy_web/templates/book/public.html.eex:32
 #: lib/listudy_web/templates/book/thumb.html.eex:40
 msgid "%{book_name} book cover"
-msgstr ""
+msgstr "copertina libro %{book_name}"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/thumb.html.eex:33
 msgid "More"
-msgstr ""
+msgstr "Scopri di più"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/public.html.eex:17
 msgid "Opening"
-msgstr ""
+msgstr "Apertura"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/public.html.eex:41
 msgid "Recommendations"
-msgstr ""
+msgstr "Raccomandazioni"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/thumb.html.eex:7
 msgid "Recommended by"
-msgstr ""
+msgstr "Raccomandato da"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/public.html.eex:9
 msgid "Tags"
-msgstr ""
+msgstr "Tag"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/recommended.html.eex:1
 msgid "Chess Books"
-msgstr ""
+msgstr "Suggeriti da Gran Maestri"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/recommended.html.eex:1
 msgid "Grandmaster recommended"
-msgstr ""
+msgstr "Libri di Scacchi"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/recommended.html.eex:10
 msgid "Have you found a recommendation from a grandmaster that is not yet in the list? Send me an email and I will add it."
-msgstr ""
+msgstr "Hai trovato un suggerimento di un gran maestro che non è ancora presente nell'elenco? Inviami un'e-mail e lo aggiungerò."
 
 #, elixir-format
 #: lib/listudy_web/templates/book/recommended.html.eex:9
 msgid "I hope this list of recommendations will help you find the best chess textbooks for you. Because who else could judge whether a chess book is good or not if not grandmasters."
-msgstr ""
+msgstr "Spero che questo elenco di raccomandazioni ti aiuti a trovare i migliori libri di scacchi per te. Perché chi altro, se non un gran maestro, può giudicare se un libro di scacchi è valido o meno?"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/recommended.html.eex:8
 msgid "These books were all recommended by chess grandmasters! Click on the more information to find out in detail what they have to say about each book."
-msgstr ""
+msgstr "Questi libri sono stati tutti consigliati da grandi maestri di scacchi! Cliccate su ulteriori informazioni per scoprire in dettaglio cosa hanno da dire su ciascun libro."
 
 #, elixir-format
 #: lib/listudy_web/templates/book/recommended.html.eex:2
 msgid "This list contains the 20 best chess books as ranked by grandmasters. I hope this list helps you to find the perfect book for you."
-msgstr ""
+msgstr "Questo elenco contiene i 20 migliori libri di scacchi suggeriti dai grandi maestri. Mi auguro che questo elenco ti aiuti a trovare il libro perfetto per te."
 
 #, elixir-format
 #: lib/listudy_web/live/book_search_live.ex:10
 msgid "Chess Book Search"
-msgstr ""
+msgstr "Cerca Libro di Scacchi"
 
 #, elixir-format
 #: lib/listudy_web/live/book_search_live.ex:12
 msgid "Search"
-msgstr ""
+msgstr "Cerca"
 
 #, elixir-format
 #: lib/listudy_web/live/book_search_live.ex:16
 msgid "by"
-msgstr ""
+msgstr "di"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/footer.html.eex:5
 #: lib/listudy_web/templates/book/footer.html.eex:9
 msgid "%{amount} books"
-msgstr ""
+msgstr "%{amount} libri"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/footer.html.eex:2
 msgid "Looking for something more specific? Take a look at these book lists:"
-msgstr ""
+msgstr "Stai cercando qualcosa di più specifico? Dai un'occhiata a questi di libri:"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/footer.html.eex:1
 msgid "More book lists"
-msgstr ""
+msgstr "Ulteriori libri"
 
 #, elixir-format
 #: lib/listudy_web/templates/book/footer.html.eex:5
 msgid "Most Grandmaster recommended books"
-msgstr ""
+msgstr "I libri più consigliati dai gran maestri"
 
 #, elixir-format
 #: lib/listudy_web/templates/player/book_recommendations.html.eex:1
 msgid "Books recommended by %{player}"
-msgstr ""
+msgstr "Libri consigliati da by %{player}"

--- a/priv/gettext/it/LC_MESSAGES/changelog.po
+++ b/priv/gettext/it/LC_MESSAGES/changelog.po
@@ -14,45 +14,45 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:17
 msgid "Added %{pieceless}"
-msgstr ""
+msgstr "Aggiunto %{pieceless}"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:13
 msgid "Added pages %{changelog}, %{thanks}, and %{pieceless_info}"
-msgstr ""
+msgstr "Aggiunte le pagine %{changelog}, %{thanks}, e %{pieceless_info}"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:1
 #: lib/listudy_web/templates/page/changelog.html.eex:10
 msgid "Changelog"
-msgstr ""
+msgstr "Changelog"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:16
 msgid "Pieceless Tactics"
-msgstr ""
+msgstr "Tattiche Senza Pezzi"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:11
 msgid "Pieceless info page"
-msgstr ""
+msgstr "Pagina d'informazioni delle tattiche senza pezzi"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:9
 msgid "Thank you"
-msgstr ""
+msgstr "Grazie"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:5
 msgid "Study progress bar"
-msgstr ""
+msgstr "Barra di progresso dello studio"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:6
 msgid "Study reset option"
-msgstr ""
+msgstr "Opzione di reset dello studio"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/changelog.html.eex:3
 msgid "Make fen copyable on endgame pages as well as link to lichess analysis page for tablebase analysis."
-msgstr ""
+msgstr "Reso il FEN copiabile nelle pagine dei finali e collegato la pagina di analisi di Lichess per l'analisi dei tablebase."

--- a/priv/gettext/it/LC_MESSAGES/chessclicker.po
+++ b/priv/gettext/it/LC_MESSAGES/chessclicker.po
@@ -14,40 +14,40 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/live/chessclicker.html.leex:74
 msgid "Continue"
-msgstr ""
+msgstr "Continua"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/chessclicker.html.leex:63
 msgid "Cost"
-msgstr ""
+msgstr "Costo"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/chessclicker.html.leex:57
 msgid "Get help by"
-msgstr ""
+msgstr "Chiedi aiuto a"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/chessclicker.html.leex:40
 msgid "Rating Points"
-msgstr ""
+msgstr "Rating"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/chessclicker.html.leex:42
 #: lib/listudy_web/templates/live/chessclicker.html.leex:64
 msgid "Rating points per second"
-msgstr ""
+msgstr "Rating al secondo"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/chessclicker.html.leex:43
 msgid "Rating points per solved tactic"
-msgstr ""
+msgstr "Rating per tattica risolta"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/chessclicker.html.leex:65
 msgid "Rating points per tactic solved"
-msgstr ""
+msgstr "Rating per tattica risolta"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/chessclicker.html.leex:63
 msgid "rating points"
-msgstr ""
+msgstr "rating"

--- a/priv/gettext/it/LC_MESSAGES/comments.po
+++ b/priv/gettext/it/LC_MESSAGES/comments.po
@@ -14,69 +14,69 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/comment/show_comments.html.eex:11
 msgid "Are you sure?"
-msgstr ""
+msgstr "Sei sicuro?"
 
 #, elixir-format
 #: lib/listudy_web/templates/comment/comment_form.html.eex:3
 msgid "Comment"
-msgstr ""
+msgstr "Commento"
 
 #, elixir-format
 #: lib/listudy_web/templates/comment/show_comments.html.eex:3
 msgid "Comments"
-msgstr ""
+msgstr "Commenti"
 
 #, elixir-format
 #: lib/listudy_web/templates/comment/show_comments.html.eex:11
 msgid "Delete"
-msgstr ""
+msgstr "Cancella"
 
 #, elixir-format
 #: lib/listudy_web/templates/comment/comment_form.html.eex:11
 msgid "Save"
-msgstr ""
+msgstr "Salva"
 
 #, elixir-format
 #: lib/listudy_web/templates/comment/show_comments.html.eex:8
 msgid "by"
-msgstr ""
+msgstr "di"
 
 #, elixir-format
 #: lib/listudy_web/controllers/comment_controller.ex:43
 msgid "Comment could not get created"
-msgstr ""
+msgstr "Non è stato possibile creare il commento"
 
 #, elixir-format
 #: lib/listudy_web/controllers/comment_controller.ex:40
 msgid "Comment created"
-msgstr ""
+msgstr "Commento creato"
 
 #, elixir-format
 #: lib/listudy_web/controllers/comment_controller.ex:26
 msgid "Comment deleted successfully."
-msgstr ""
+msgstr "Commento cancellato con successo."
 
 #, elixir-format
 #: lib/listudy_web/controllers/comment_controller.ex:48
 msgid "Error"
-msgstr ""
+msgstr "Errore"
 
 #, elixir-format
 #: lib/listudy_web/controllers/comment_controller.ex:20
 msgid "You're not allowed to do that."
-msgstr ""
+msgstr "Non ti è permesso farlo."
 
 #, elixir-format
 #: lib/listudy_web/templates/comment/comment_form.html.eex:16
 msgid "%{register} to comment"
-msgstr ""
+msgstr "%{register} per commentare"
 
 #, elixir-format
 #: lib/listudy_web/templates/comment/show_comments.html.eex:17
 msgid "No comments yet, be the first to write one!"
-msgstr ""
+msgstr "Ancora nessun commento, sii il primo a scriverne uno!"
 
 #, elixir-format
 #: lib/listudy_web/templates/comment/comment_form.html.eex:15
 msgid "Register"
-msgstr ""
+msgstr "Registrati"

--- a/priv/gettext/it/LC_MESSAGES/copyright.po
+++ b/priv/gettext/it/LC_MESSAGES/copyright.po
@@ -14,54 +14,54 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:12
 msgid "Copyright holders"
-msgstr ""
+msgstr "Detentori del Copyright"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:2
 msgid "English version of the Copyright Policy"
-msgstr ""
+msgstr "Versione in inglese della Policy di Copyright"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:13
 msgid "If you believe that someone has uploaded or posted content of yours on Listudy.org without your permission, please contact us at: copyright@listudy.org"
-msgstr ""
+msgstr "Se credi che qualcuno abbia caricato o pubblicato un tuo contenuto su Listudy.org senza il tuo permesso, contattaci all'indirizzo: copyright@listudy.org."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:6
 msgid "Introduction"
-msgstr ""
+msgstr "Introduzione"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:4
 msgid "Last edited:"
-msgstr ""
+msgstr "Ultima modifica:"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:16
 msgid "Listudy can change this policy at its discretion."
-msgstr ""
+msgstr "Listudy può modificare questa policy a sua discrezione."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:7
 msgid "Listudy respects and recognizes the copyright of third parties. You are only allowed to publish public content on Listudy, for which you have all necessary rights."
-msgstr ""
+msgstr "Listudy rispetta e riconosce il copyright di terzi. Ti è concesso pubblicare su Listudy solo contenuti pubblici per i quali possiedi tutti i diritti necessari."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:15
 msgid "Other"
-msgstr ""
+msgstr "Altro"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:9
 msgid "PGN files"
-msgstr ""
+msgstr "File PGN"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:2
 msgid "Translated copyright policies shall only serve as an informal source of information. Please read the english version for the official version applicable to the site."
-msgstr ""
+msgstr "Le traduzioni delle policy di copyright servono solo come fonte informale di informazioni. Si prega di leggere la versione inglese per conoscere la versione ufficiale applicabile al sito."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/copyright.html.eex:10
 msgid "You are only allowed to make public studies using PGN files, for which you have all necessary rights to. Do not copy PGN files from other websites for which you do not have the rights. This applies especially, but is not limited to, paid PGN files."
-msgstr ""
+msgstr "È possibile rendere pubblici solamente gli studi che utilizzano file PGN, per i quali si possiedono tutti i diritti necessari. Non copiare file PGN da altri siti Web per i quali non hai diritti. Questo vale soprattutto, ma non solo, per i file PGN a pagamento."

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -81,7 +81,7 @@ msgstr "Blog"
 #, elixir-format
 #: lib/listudy_web/templates/layout/_header.html.eex:17
 msgid "Create a new Study"
-msgstr "Crea nuovo Studio"
+msgstr "Crea un nuovo Studio"
 
 #, elixir-format
 #: lib/listudy_web/templates/pow/registration/new.html.eex:36
@@ -119,7 +119,7 @@ msgstr "Privacy"
 #: lib/listudy_web/templates/page/privacy.html.eex:1
 #: lib/listudy_web/templates/pow/registration/new.html.eex:38
 msgid "Privacy Policy"
-msgstr "Politica della Privacy"
+msgstr "Policy sulla Privacy"
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_header.html.eex:77
@@ -129,7 +129,7 @@ msgstr "Profilo"
 #, elixir-format
 #: lib/listudy_web/templates/pow/registration/new.html.eex:34
 msgid "Register to get access to all features."
-msgstr "Registrati per accedere a tutti i funzionalità."
+msgstr "Registrati per accedere a tutte le funzionalità."
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_footer.html.eex:6
@@ -140,12 +140,12 @@ msgstr "Termini del Servizio"
 #, elixir-format
 #: lib/listudy_web/templates/pow/registration/new.html.eex:36
 msgid "The email is used to log in. It doesn't have to be real, as long as you remember it."
-msgstr "Questa email è usata solo per loggarti. Non deve essere reale, l'importante è che tu la ricordi."
+msgstr "Questa e-mail è usata solo per effettuare il login. Non deve essere reale, purché te la ricordi."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/imprint.html.eex:2
 msgid "The provider of this website is Arne Vogel."
-msgstr "Il provider di questo sito è Arne Vogel."
+msgstr "Il provider di questo sito Web è Arne Vogel."
 
 #, elixir-format
 #: lib/listudy_web/controllers/page_controller.ex:27
@@ -194,7 +194,7 @@ msgstr "Creato il"
 #, elixir-format
 #: lib/listudy_web/templates/layout/_footer.html.eex:19
 msgid "Daily Puzzle"
-msgstr "Puzzle Giornaliero"
+msgstr "Problema del Giorno"
 
 #, elixir-format
 #: lib/listudy_web/templates/pow/registration/edit.html.eex:36
@@ -215,7 +215,7 @@ msgstr "Ultimo aggiornamento"
 #, elixir-format
 #: lib/listudy_web/templates/layout/_footer.html.eex:20
 msgid "Make your own Tactic"
-msgstr "Crea le tue Tattiche"
+msgstr "Crea la tua Tattica"
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_header.html.eex:24
@@ -226,7 +226,7 @@ msgstr "Tattiche"
 #, elixir-format
 #: lib/listudy_web/templates/pow/registration/edit.html.eex:37
 msgid "This can not be reversed! Are you sure?"
-msgstr "Non si può tornare indietro. Sei sicuro?"
+msgstr "Non si può annullare. Sei sicuro?"
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_header.html.eex:74
@@ -241,7 +241,7 @@ msgstr "Indietro"
 #, elixir-format
 #: lib/listudy_web/templates/pow/registration/new.html.eex:40
 msgid "Before creating your account, please read the %{privacy_policy} and %{tos}. By creating the account, you agree to those terms."
-msgstr "Prima di creare il tuo account, per favore leggi %{privacy_policy} e %{tos}. Creando l'account, acconsenti ai termini."
+msgstr "Prima di creare il tuo account, per favore leggi %{privacy_policy} e %{tos}. Creando l'account, acconsenti a questi termini."
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_header.html.eex:72
@@ -278,7 +278,7 @@ msgstr "Seleziona un colore:"
 #, elixir-format
 #: lib/listudy_web/templates/layout/_header.html.eex:101
 msgid "Select a piece set:"
-msgstr "Seleziona un set di scacchi:"
+msgstr "Seleziona un set di pezzi:"
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_header.html.eex:71
@@ -309,40 +309,40 @@ msgstr "Webmaster"
 #, elixir-format
 #: lib/listudy_web/pow/messages.ex:9
 msgid "The provided login details did not work. Make sure to log in with your email and not your username!"
-msgstr "Le informazioni fornite per il login non hanno funzionato. Assicurati di accedere con la tua email e non con il tuo username"
+msgstr "Le informazioni fornite per il login non hanno funzionato. Assicurati di accedere col tuo indirizzo e-mail e non con il tuo username"
 
 #, elixir-format
 #: lib/listudy_web/templates/pow/session/new.html.eex:11
 msgid "Use your email to log in."
-msgstr "Usa la tua email per accedere."
+msgstr "Usa la tua e-mail per accedere."
 
 #, elixir-format
 #: lib/listudy_web/templates/pow/session/new.html.eex:18
 msgid "Your session will be persistent. Only use on your own devices."
-msgstr "La tua sessione sarà persistente. Usa solo sui tuoi dispositivi."
+msgstr "La tua sessione sarà persistente. Usata solo sui tuoi dispositivi."
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_footer.html.eex:10
 msgid "Changelog"
-msgstr ""
+msgstr "Changelog"
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_footer.html.eex:18
 #: lib/listudy_web/templates/layout/_header.html.eex:28
 msgid "Pieceless Tactics"
-msgstr ""
+msgstr "Tattiche Senza Pezzi"
 
 #, elixir-format
 #: lib/listudy_web/templates/layout/_footer.html.eex:9
 msgid "Thank you!"
-msgstr ""
+msgstr "Grazie!"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:8
 msgid "black"
-msgstr ""
+msgstr "nero"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:9
 msgid "white"
-msgstr ""
+msgstr "bianco"

--- a/priv/gettext/it/LC_MESSAGES/endgame.po
+++ b/priv/gettext/it/LC_MESSAGES/endgame.po
@@ -14,42 +14,42 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:94
 msgid "Bishop + Bishop"
-msgstr ""
+msgstr "Alfiere + Alfiere"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:109
 msgid "Bishop + Knight"
-msgstr ""
+msgstr "Alfiere + Cavallo"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:198
 msgid "Bishops and Pawns"
-msgstr ""
+msgstr "Alfiere e pedoni"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:328
 msgid "Bishops and/or knights against rook, with and without pawns."
-msgstr ""
+msgstr "Alfieri e/o Cavalli contro Torre, con e senza pedoni."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:60
 msgid "Checkmating"
-msgstr ""
+msgstr "Scacco matto"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:441
 msgid "Chess Fundamentals"
-msgstr ""
+msgstr "Fondamenti degli Scacchi"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:231
 msgid "Endgames with Knights, Bishops and Pawns."
-msgstr ""
+msgstr "Finali con Cavalli, Alfieri e pedoni."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:199
 msgid "Endgames with only Bishops and Pawns on the board."
-msgstr ""
+msgstr "Finali con solo Alfieri e pedoni sulla scacchiera."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:136
@@ -59,17 +59,17 @@ msgstr ""
 #: lib/listudy_web/controllers/endgame_controller.ex:353 lib/listudy_web/controllers/endgame_controller.ex:378
 #: lib/listudy_web/controllers/endgame_controller.ex:406 lib/listudy_web/controllers/endgame_controller.ex:460
 msgid "Endings of Games"
-msgstr ""
+msgstr "Finali di Partita"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:442
 msgid "From the Capablancas \"Chess Fundamentals\"."
-msgstr ""
+msgstr "Dal libro \"Fondamenti degli Scacchi\" di Capablanca."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:423
 msgid "From the book \"Analysis of the  Chess Ending King and Queen against King and Rook\"."
-msgstr ""
+msgstr "Dal libro \"Analysis of the Chess Ending King and Queen against King and Rook\"."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:138
@@ -79,247 +79,247 @@ msgstr ""
 #: lib/listudy_web/controllers/endgame_controller.ex:355 lib/listudy_web/controllers/endgame_controller.ex:380
 #: lib/listudy_web/controllers/endgame_controller.ex:408 lib/listudy_web/controllers/endgame_controller.ex:462
 msgid "From the book \"Chess Studies, Or, Endings of Games\"."
-msgstr ""
+msgstr "Dal libro \"Chess Studies, Or, Endings of Games\"."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:127
 msgid "King and Pawn Endgames"
-msgstr ""
+msgstr "Finali di Re e pedone"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:421
 msgid "King and Queen against King and Rook"
-msgstr ""
+msgstr "Re e Regina contro Re e Torre"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:230
 msgid "Knights, Bishops and Pawns"
-msgstr ""
+msgstr "Cavalli, Alfieri e pedoni"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:61
 msgid "Learn the basic checkmating techniques."
-msgstr ""
+msgstr "Impara le tecniche base per dare scacco matto."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:327
 msgid "Minor pieces against Rook endgames."
-msgstr ""
+msgstr "Finali di pezzi minori contro Torre."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:178
 msgid "Obtaining a Passed Pawn"
-msgstr ""
+msgstr "Ottenere un pedone passato"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:167
 msgid "Pawn Endings"
-msgstr ""
+msgstr "Finali di pedone"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:159
 msgid "Pawn Promotion"
-msgstr ""
+msgstr "Promozione del pedone"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:69
 msgid "Queen"
-msgstr ""
+msgstr "Regina"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:455
 msgid "Queen against Minor Pieces"
-msgstr ""
+msgstr "Regina contro pezzi minori"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:348
 msgid "Queen against Pawns"
-msgstr ""
+msgstr "Regina contro pedoni"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:401
 #: lib/listudy_web/controllers/endgame_controller.ex:402
 msgid "Queen against Rook"
-msgstr ""
+msgstr "Regina contro Torre"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:456
 msgid "Queen against minor pieces."
-msgstr ""
+msgstr "Regina contro pezzi minori."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:349
 #: lib/listudy_web/controllers/endgame_controller.ex:350
 msgid "Queen against pawn endgames."
-msgstr ""
+msgstr "Finali di Regina contro pedone."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:373
 msgid "Queens and Pawns"
-msgstr ""
+msgstr "Regina e pedoni"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:374
 msgid "Queens and pawn endgames."
-msgstr ""
+msgstr "Finali di Regine e pedone."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:81
 msgid "Rook"
-msgstr ""
+msgstr "Torre"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:281
 msgid "Rook against Pawn endgames."
-msgstr ""
+msgstr "Finali di Torre contro pedone."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:280
 msgid "Rook against Pawns"
-msgstr ""
+msgstr "Torre contro pedoni"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:303
 msgid "Rook against minor Pieces"
-msgstr ""
+msgstr "Torre contro pezzi minori"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:304
 msgid "Rook against minor pieces endgames."
-msgstr ""
+msgstr "Finali di Torre contro pezzi minori."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:306
 msgid "Rook and pawn against bishop or knight, with and without pawns."
-msgstr ""
+msgstr "Torre e pedone contro Alfiere o Cavallo, con e senza pedoni."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:185
 msgid "The Opposition"
-msgstr ""
+msgstr "Opposizione"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:232
 msgid "This chapter has endgames about Knight and Bishop endings."
-msgstr ""
+msgstr "Questo capitolo contiene finali di Cavallo e Alfiere."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:200
 msgid "This chapter has endgames about Pawn and Bishop endings."
-msgstr ""
+msgstr "Questo capitolo contiene finali di pedone e Alfiere."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:130
 msgid "This chapter has endgames about the King and Pawn endgame. Many of the examples are taken from Capablancas \"Chess Fundamentals\"."
-msgstr ""
+msgstr "Questo capitolo contiene finali di Re e pedone. Molti esempi sono tratti dal libro \"Fondamenti degli Scacchi\" di Capablanca."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:63
 msgid "This chapter has endgames for checkmating with queen, rook, bishop + knight and bishop + bishop."
-msgstr ""
+msgstr "Questo capitolo contiene finali per dare scacco matto con Regina, Torre, Alfiere + Cavallo, e Alfiere + Alfiere"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:375
 msgid "Train endgames with queens and pawns on the board."
-msgstr ""
+msgstr "Allena i finali con Regine e pedoni sulla scacchiera."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:457
 msgid "Train queen and minor piece endgames."
-msgstr ""
+msgstr "Allena i finali di Regina e pezzi minori."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:403
 msgid "Train queen and rook endgames."
-msgstr ""
+msgstr "Allena i finali di Regina e Torre."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:282
 msgid "Train rook against pawn endgames."
-msgstr ""
+msgstr "Allena i finali di Torre contro pedone."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:254
 msgid "Two Minor Pieces against one Minor Piece"
-msgstr ""
+msgstr "Due pezzi minori contro un pezzo minore"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:257
 msgid "Two against one."
-msgstr ""
+msgstr "Due contro uno."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:128
 msgid "Win games with only Pawns on the board"
-msgstr ""
+msgstr "Vinci con solo pedoni sulla scacchiera"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/tactics.html.leex:25
 msgid "Currently playing tactics by:"
-msgstr ""
+msgstr "Attualmente stai giocando tattiche di:"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/tactics.html.leex:22
 msgid "Currently playing tactics from the event:"
-msgstr ""
+msgstr "Attualmente stai giocando tattiche dell'evento:"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/tactics.html.leex:19
 msgid "Currently training in the motif:"
-msgstr ""
+msgstr "Attualmente stai allenando il tema:"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/tactics.html.leex:16
 msgid "Currently training in the opening:"
-msgstr ""
+msgstr "Attualmente stai allenando l'apertura:"
 
 #, elixir-format
 #: lib/listudy_web/templates/endgame/game.html.eex:2
 #: lib/listudy_web/templates/endgame/index.html.eex:1
 msgid "Endgames"
-msgstr ""
+msgstr "Finali"
 
 #, elixir-format
 #: lib/listudy_web/views/endgame_view.ex:7
 msgid "Next"
-msgstr ""
+msgstr "Prossimo"
 
 #, elixir-format
 #: lib/listudy_web/templates/endgame/game.html.eex:25
 msgid "Reset"
-msgstr ""
+msgstr "Reimposta"
 
 #, elixir-format
 #: lib/listudy_web/templates/endgame/game.html.eex:48
 msgid "Success!"
-msgstr ""
+msgstr "Successo!"
 
 #, elixir-format
 #: lib/listudy_web/templates/endgame/game.html.eex:49
 msgid "Try again!"
-msgstr ""
+msgstr "Prova ancora!"
 
 #, elixir-format
 #: lib/listudy_web/templates/endgame/game.html.eex:15
 msgid "White to play and"
-msgstr ""
+msgstr "Il Bianco muove e"
 
 #, elixir-format
 #: lib/listudy_web/templates/endgame/index.html.eex:8
 msgid "Learn"
-msgstr ""
+msgstr "Impara"
 
 #, elixir-format
 #: lib/listudy_web/templates/endgame/index.html.eex:2
 msgid "No idea what to do in the endgame? Learn endgames by playing against stockfish."
-msgstr ""
+msgstr "Non hai idea di cosa fare nei finali? Impara i finali giocando contro Stockfish."
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:326
 msgid "Minor pieces against Rook"
-msgstr ""
+msgstr "Pezzi minori contro Torre"
 
 #, elixir-format
 #: lib/listudy_web/controllers/endgame_controller.ex:256
 msgid "Two minor pieces against one minor piece, with and without pawns."
-msgstr ""
+msgstr "Due pezzi minori contro un pezzo minore, con e senza pedoni."

--- a/priv/gettext/it/LC_MESSAGES/errors.po
+++ b/priv/gettext/it/LC_MESSAGES/errors.po
@@ -12,76 +12,76 @@ msgstr ""
 "Plural-Forms: nplurals=2\n"
 
 msgid "can't be blank"
-msgstr ""
+msgstr "non può essere vuoto"
 
 msgid "has already been taken"
-msgstr ""
+msgstr "è stato già preso"
 
 msgid "is invalid"
-msgstr ""
+msgstr "è invalido"
 
 msgid "must be accepted"
-msgstr ""
+msgstr "deve essere accettato"
 
 msgid "has invalid format"
-msgstr ""
+msgstr "ha un formato non valido"
 
 msgid "has an invalid entry"
-msgstr ""
+msgstr "ha una voce non valida"
 
 msgid "is reserved"
-msgstr ""
+msgstr "è riservato"
 
 msgid "does not match confirmation"
-msgstr ""
+msgstr "non rispetta la conferma"
 
 msgid "is still associated with this entry"
-msgstr ""
+msgstr "è ancora associato con questa voce"
 
 msgid "are still associated with this entry"
-msgstr ""
+msgstr "sono ancora associati con questa voce"
 
 msgid "should be %{count} character(s)"
 msgid_plural "should be %{count} character(s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "deve avere %{count} caratteri"
+msgstr[1] "devono avere %{count} caratteri"
 
 msgid "should have %{count} item(s)"
 msgid_plural "should have %{count} item(s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "dovrebbe avere %{count} elementi"
+msgstr[1] "dovrebbero avere %{count} elementi"
 
 msgid "should be at least %{count} character(s)"
 msgid_plural "should be at least %{count} character(s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "dovrebbe avere almeno %{count} caratteri"
+msgstr[1] "dovrebbero avere almeno %{count} caratteri"
 
 msgid "should have at least %{count} item(s)"
 msgid_plural "should have at least %{count} item(s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "dovrebbe avere almeno %{count} elementi"
+msgstr[1] "dovrebbero avere almeno %{count} elementi"
 
 msgid "should be at most %{count} character(s)"
 msgid_plural "should be at most %{count} character(s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "dovrebbe avere al massimo %{count} caratteri"
+msgstr[1] "dovrebbero avere al massimo %{count} caratteri"
 
 msgid "should have at most %{count} item(s)"
 msgid_plural "should have at most %{count} item(s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "dovrebbe avere al massimo %{count} elementi"
+msgstr[1] "dovrebbero avere al massimo %{count} elementi"
 
 msgid "must be less than %{number}"
-msgstr ""
+msgstr "deve essere minore di %{number}"
 
 msgid "must be greater than %{number}"
-msgstr ""
+msgstr "deve essere maggiore di %{number}"
 
 msgid "must be less than or equal to %{number}"
-msgstr ""
+msgstr "deve essere minore di o uguale a %{number}"
 
 msgid "must be greater than or equal to %{number}"
-msgstr ""
+msgstr "deve essere maggiore di o uguale a %{number}"
 
 msgid "must be equal to %{number}"
-msgstr ""
+msgstr "deve essere uguale a %{number}"

--- a/priv/gettext/it/LC_MESSAGES/index.po
+++ b/priv/gettext/it/LC_MESSAGES/index.po
@@ -14,226 +14,226 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:46
 msgid "All blog posts"
-msgstr ""
+msgstr "Tutti i post del blog"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:31
 msgid "Become unbeatable in endgames."
-msgstr ""
+msgstr "Diventa imbattibile nei finali."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:4
 msgid "Better train openings, endgames and tactics with the help of systematic repetition."
-msgstr ""
+msgstr "Meglio allenare aperture, finali e tattiche con l'aiuto della ripetizione sistematica."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:53
 msgid "Blind Tactics"
-msgstr ""
+msgstr "Tattiche alla Cieca"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:24
 msgid "Books"
-msgstr ""
+msgstr "Libri"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:60
 msgid "Contribute"
-msgstr ""
+msgstr "Contribuisci"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:91
 msgid "Daily Puzzle"
-msgstr ""
+msgstr "Problema del Giorno"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:26
 msgid "Discover the greatest books with the help of Grandmaster recommendations."
-msgstr ""
+msgstr "Scopri i libri migliori coi consigli dei Gran Maestri."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:73
 msgid "Distribute copies of your modified versions"
-msgstr ""
+msgstr "Distribuisci copie delle tue versioni modificate"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:30
 #: lib/listudy_web/templates/page/index.html.eex:33
 msgid "Endgames"
-msgstr ""
+msgstr "Finali"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:86
 msgid "Events"
-msgstr ""
+msgstr "Eventi"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:81
 msgid "Explore"
-msgstr ""
+msgstr "Esplora"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:12
 #: lib/listudy_web/templates/page/index.html.eex:27
 msgid "Explore the"
-msgstr ""
+msgstr "Esplora"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:25
 msgid "Find the best chess books for you."
-msgstr ""
+msgstr "Trova il libro migliore per te."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:67
 msgid "Free & Open Source"
-msgstr ""
+msgstr "Libero & Open Source"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:17
 msgid "Get better at identifying and exploiting tactics."
-msgstr ""
+msgstr "Diventa più bravo a identificare e sfruttare le tattiche."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:51
 msgid "Improve your visualization skills with blind tactics."
-msgstr ""
+msgstr "Migliora le tue capacità di visualizzazione con le tattiche alla cieca."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:40
 msgid "Latest blog posts"
-msgstr ""
+msgstr "Ultimi post del blog"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:84
 msgid "Motifs"
-msgstr ""
+msgstr "Temi"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:83
 msgid "Openings"
-msgstr ""
+msgstr "Aperture"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:11
 msgid "Play against your opening repertoire and learn them playfully and with scientifically effective methods."
-msgstr ""
+msgstr "Gioca contro il tuo repertorio di aperture e imparale in modo divertente e con metodi scientificamente efficaci."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:85
 msgid "Players"
-msgstr ""
+msgstr "Giocatori"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:72
 msgid "Redistribute the software"
-msgstr ""
+msgstr "Ridistribuisci il software"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:70
 msgid "Run the server yourself as you wish, for any purpose"
-msgstr ""
+msgstr "Avvia il server tu stesso, come desideri, per qualsiasi scopo"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:52
 msgid "Solve tactics while only seeing the board from 2 moves ago."
-msgstr ""
+msgstr "Risolvi tattiche vedendo la scacchiera di 2 mosse prima."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:9
 msgid "Study Openings"
-msgstr ""
+msgstr "Studia le Aperture"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:71
 msgid "Study how the software works, and change it so it does your computing as you wish"
-msgstr ""
+msgstr "Studia il funzionamento del software e modificalo come desideri."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:18
 msgid "Tactics"
-msgstr ""
+msgstr "Tattiche"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:62
 msgid "The support can look different. Report bugs if you find any, fix bugs if you can, help translate Listudy into other languages."
-msgstr ""
+msgstr "Il support può apparire differente. Segnala i bug se ne trovi, correggi i bug se puoi, aiutate a tradurre Listudy in altre lingue."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:15
 msgid "Train Tactics"
-msgstr ""
+msgstr "Allena le Tattiche"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:32
 msgid "Train endgames against Stockfish to become skilled and ready to take on any human opponent."
-msgstr ""
+msgstr "Allena i finali contro Stockfish per diventare abile e pronto ad affrontare qualsiasi avversario umano."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:16
 msgid "Train tactics with thousands of tactical sequences from real games."
-msgstr ""
+msgstr "Allena le tattiche con migliaia di sequenze tratte da partite reali."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:33
 msgid "Train your endgame abilities: "
-msgstr ""
+msgstr "Allena le tue abilità nei finali: "
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:18
 msgid "Train your tactical abilities: "
-msgstr ""
+msgstr "Allena le tue capacità tattiche: "
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:53
 msgid "Train your visualization skills: "
-msgstr ""
+msgstr "Allena le tue capacità di visualizzazione: "
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:10
 msgid "Use Listudy to better memorize openings. "
-msgstr ""
+msgstr "Usa Listudy per migliorare la memorizzazione delle aperture. "
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:63
 msgid "Visit github to find out more about how you can help:"
-msgstr ""
+msgstr "Visita Github per scoprire di più su come puoi aiutare:"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:50
 msgid "Visualization"
-msgstr ""
+msgstr "Visualizzazione"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:2
 msgid "Welcome to %{name}!"
-msgstr ""
+msgstr "Benvenuto in %{name}!"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:3
 msgid "With %{name} you can improve your chess skills with the help of spaced repetition."
-msgstr ""
+msgstr "Con %{name} puoi migliorare le tue abilità scacchistiche con l'aiuto della ripetizione spaziata."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:75
 msgid "You can find the source code running Listudy on github:"
-msgstr ""
+msgstr "Puoi trovare il codice sorgente di Listudy su Github:"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:61
 msgid "You can help make Listudy better."
-msgstr ""
+msgstr "Puoi aiutare a rendere Listudy migliore."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:68
 msgid "Your freedoms are important. That's why you have the rights to:"
-msgstr ""
+msgstr "Le tue libertà sono importanti. Ecco perché hai diritto a:"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:27
 msgid "best chess books"
-msgstr ""
+msgstr "i migliori libri di scacchi"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/index.html.eex:12
 msgid "latest openings"
-msgstr ""
+msgstr "le ultime aperture"

--- a/priv/gettext/it/LC_MESSAGES/page_descriptions.po
+++ b/priv/gettext/it/LC_MESSAGES/page_descriptions.po
@@ -14,51 +14,51 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:47
 msgid "Explore our collection of tactics taken from games by %{name}."
-msgstr ""
+msgstr "Esplora la nostra collezione di tattiche tratte dalle partite di %{name}."
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:27
 msgid "Get better at %{name} tactics with our huge library of puzzles taken from real games. Explore our free collection of %{name} tactics."
-msgstr ""
+msgstr "Migliora le tattiche di %{nome} con la nostra vasta libreria di problemi tratti da partite reali. Esplora la nostra raccolta gratuita di tattiche di %{nome}."
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:74
 msgid "Get better in the %{name} opening. Study the opening and learn from traps and tactics collected from real games."
-msgstr ""
+msgstr "Migliora nell'apertura %{name}. Studia l'apertura e impara dalle trappole e tattiche collezionate in partite reali."
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:126
 msgid "Improve your chess game on Listudy"
-msgstr ""
+msgstr "Migliora il tuo gioco su Listudy"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:93
 msgid "Learn chess endgames interactively playing against Stockfish"
-msgstr ""
+msgstr "Impara i finali in modo interattivo giocando contro Stockfish"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:15
 msgid "Play against Stockfish Online - Unlimited and for Free"
-msgstr ""
+msgstr "Gioca online contro Stockfish - Illimitatamente e Gratuitamente"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:35
 msgid "Play tactics from the event %{}. Are you better than the professionals?"
-msgstr ""
+msgstr "Gioca tattiche tratte dall'evento %{}. Sei migliore dei professionisti?"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:24
 msgid "Search for studies to train specific openings"
-msgstr ""
+msgstr "Cerca studi per allenare aperture specifiche"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:8
 msgid "Solve the Daily Chess Puzzle! Updated every day from our list of best puzzles."
-msgstr ""
+msgstr "Risolvi il Problema del Giorno! Aggiornato ogni giorno dalla nostra lista di problemi migliori."
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_description.ex:60
 msgid "A chess book recommendation by %{player}"
 msgid_plural "%{count} chess book recommendations by %{player}"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Un libro di scacchi raccomandato da %{player}"
+msgstr[1] "%{count} libri di scacchi raccomandati da %{player}"

--- a/priv/gettext/it/LC_MESSAGES/page_titles.po
+++ b/priv/gettext/it/LC_MESSAGES/page_titles.po
@@ -14,59 +14,59 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:31
 msgid "Achievements"
-msgstr ""
+msgstr "Traguardi"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:16
 msgid "Blind Tactics"
-msgstr ""
+msgstr "Tattiche alla Cieca"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:13
 msgid "Daily Chess Puzzle"
-msgstr ""
+msgstr "Problema del Giorno"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:62
 msgid "Endgames"
-msgstr ""
+msgstr "Finali"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:28
 msgid "Play against Stockfish Online"
-msgstr ""
+msgstr "Gioca online contro Stockfish"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:42
 msgid "Search Studies"
-msgstr ""
+msgstr "Cerca Studi"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:43
 msgid "Tactics"
-msgstr ""
+msgstr "Tattiche"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:22
 msgid "Changelog"
-msgstr ""
+msgstr "Changelog"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:19
 msgid "Pieceless Tactics"
-msgstr ""
+msgstr "Tattiche Senza Pezzi"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:25
 msgid "Thank you!"
-msgstr ""
+msgstr "Grazie!"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:34
 msgid "Improve your chess game with spaced repetition"
-msgstr ""
+msgstr "Migliora il tuo gioco con la ripetizione spaziata"
 
 #, elixir-format
 #: lib/listudy_web/views/helpers/page_title.ex:89
 msgid "Books Recommended by %{player}"
-msgstr ""
+msgstr "Libri Suggeriti da %{player}"

--- a/priv/gettext/it/LC_MESSAGES/play_stockfish.po
+++ b/priv/gettext/it/LC_MESSAGES/play_stockfish.po
@@ -14,49 +14,49 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:32
 msgid "Official Stockfish Website"
-msgstr ""
+msgstr "Sito ufficiale di Stockfish"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:26
 msgid "Play against Stockfish:"
-msgstr ""
+msgstr "Gioca contro Stockfish:"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:29
 msgid "Stockfish is one of the best chess engines avaliable. And with the help of WebAssembly the engine can now also be executed online in the browser. This means that the engine is running in your own browser."
-msgstr ""
+msgstr "Stockfish è uno dei migliori motori scacchistici in circolazione. E con l'aiuto di WebAssembly, il motore può ora essere eseguito anche nel browser. Ciò significa che il motore viene eseguito direttamente nel vostro browser."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:35
 msgid "Thanks to Niklas Fiekas for the WebAssembly port of Stockfish!"
-msgstr ""
+msgstr "Grazie a Niklas Fiekas per il porting di Stockfish in WebAssembly!"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:31
 msgid "Thanks to the developers of stockfish!"
-msgstr ""
+msgstr "Grazie agli sviluppatori di Stockfish!"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:27
 msgid "learn with the best chess engine."
-msgstr ""
+msgstr "impara col miglior motore scacchistico."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:36
 msgid "stockfish.wasm"
-msgstr ""
+msgstr "stockfish.wasm"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:1
 msgid "Play against Stockfish"
-msgstr ""
+msgstr "Gioca contro Stockfish"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:10
 msgid "Reset as %{white}, %{black}."
-msgstr ""
+msgstr "Ripristina come %{white}, %{black}."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/play_stockfish.html.eex:11
 msgid "Takeback"
-msgstr ""
+msgstr "Ritira la mossa"

--- a/priv/gettext/it/LC_MESSAGES/privacy.po
+++ b/priv/gettext/it/LC_MESSAGES/privacy.po
@@ -14,171 +14,171 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:44
 msgid "A cookie is a text string that Listudy stores in your browser in order to keep you logged in throughout sessions and save your site preferences."
-msgstr ""
+msgstr "Un cookie è una stringa di testo che Listudy memorizza nel tuo browser per mantenere l'accesso durante le sessioni e salvare le tue preferenze del sito."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:16
 #: lib/listudy_web/templates/page/privacy.html.eex:55
 msgid "Closing your account"
-msgstr ""
+msgstr "Chiusura dell'account"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:53
 msgid "Collected information is stored on Listudy’ servers, which are hosted by DigitalOcean."
-msgstr ""
+msgstr "Le informazioni raccolte vengono memorizzate sui server di Listudy, che sono gestiti da DigitalOcean."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:43
 msgid "Cookies"
-msgstr ""
+msgstr "Cookie"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:39
 msgid "Disclosing your information"
-msgstr ""
+msgstr "Divulgazione delle informazioni"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:2
 msgid "English version of the Privacy Policy"
-msgstr ""
+msgstr "Versione inglese dell'Informativa sulla Privacy"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:13
 msgid "How cookies are used"
-msgstr ""
+msgstr "Come sono usati i cookie"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:41
 msgid "If Listudy is sold, the data provided by the user (such as emails, pgns, comments) will be transferred to a new third party owner."
-msgstr ""
+msgstr "In caso di vendita di Listudy, i dati forniti dall'utente (come e-mail, PGN, commenti) saranno trasferiti al nuovo proprietario."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:24
 msgid "If you create an account, you will be asked to provide a email address. This email address does not have to be a real email address."
-msgstr ""
+msgstr "Se crei un account, ti verrà chiesto di fornire un indirizzo e-mail. Questo indirizzo e-mail non deve essere necessariamente un indirizzo reale."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:21
 msgid "Information that Listudy collects:"
-msgstr ""
+msgstr "Informazioni che Listudy raccoglie:"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:48
 msgid "Information you delete is deleted from the live site but remains in Listudy’ backups for up to one year."
-msgstr ""
+msgstr "Le informazioni eliminate vengono eliminate dal sito, ma rimangono nei backup di Listudy per un periodo massimo di un anno."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:6
 msgid "Introduction"
-msgstr ""
+msgstr "Introduzione"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:4
 msgid "Last edited:"
-msgstr ""
+msgstr "Ultima modifica:"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:60
 msgid "Listudy can change this policy at its discretion."
-msgstr ""
+msgstr "Listudy può modificare questa policy a sua discrezione."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:7
 msgid "Listudy.org (“Listudy”) is an online chess site. Users can optionally register for an account; however, certain features are available for registered users only. This is because Listudy needs basic information from its users in order to function."
-msgstr ""
+msgstr "Listudy.org (“Listudy“) è un sito di scacchi online. Gli utenti possono facoltativamente registrare un account; tuttavia, alcune funzioni sono disponibili solamente per gli utenti registrati. Questo perché Listudy ha bisogno di informazioni di base da parte dei suoi utenti per poter funzionare."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:14
 #: lib/listudy_web/templates/page/privacy.html.eex:46
 msgid "Managing your information"
-msgstr ""
+msgstr "Gestisci le tue informazioni"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:17
 #: lib/listudy_web/templates/page/privacy.html.eex:59
 msgid "Other"
-msgstr ""
+msgstr "Altro"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:57
 msgid "Send me an email if you want to close your account."
-msgstr ""
+msgstr "Inviami una e-mail se vuoi chiudere il tuo account."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:15
 #: lib/listudy_web/templates/page/privacy.html.eex:52
 msgid "Storage of the collected information"
-msgstr ""
+msgstr "Conservazione delle informazioni raccolte"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:27
 #: lib/listudy_web/templates/page/privacy.html.eex:36
 msgid "Technical information"
-msgstr ""
+msgstr "Informazioni tecniche"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:37
 msgid "This information is stored to detect attacks and malicious access to the site."
-msgstr ""
+msgstr "Queste informazioni vengono memorizzate per rilevare attacchi e accessi illeciti al sito."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:9
 msgid "This privacy policy will detail:"
-msgstr ""
+msgstr "La presente informativa sulla privacy illustra in dettaglio:"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:2
 msgid "Translated privacy policies shall only serve as an informal source of information. Please read the english version for the official version applicable to the site."
-msgstr ""
+msgstr "Le traduzioni delle informative sulla privacy servono solo come fonte informale di informazioni. Si prega di leggere la versione inglese per conoscere la versione ufficiale applicabile al sito."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:23
 #: lib/listudy_web/templates/page/privacy.html.eex:33
 msgid "User submitted information"
-msgstr ""
+msgstr "Informazioni fornite dall'utente"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:11
 #: lib/listudy_web/templates/page/privacy.html.eex:20
 msgid "What information Listudy collects"
-msgstr ""
+msgstr "Quali informazioni raccoglie Listudy"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:28
 msgid "When you visit Listudy, some information about the request is logged on the server. This information includes the time of the request, the HTTP method, the URI of the request, the status code generated by the server and the referrer of the request."
-msgstr ""
+msgstr "Quando visiti Listudy, alcune informazioni relativa alla tua richiesta vengono conservate sul server. Queste informazioni includono l'ora della richiesta, il metodo HTTP, l'URI della richiesta, il codice di stato generato dal server e il referente della richiesta."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:12
 msgid "Why this information is collected and how it's used"
-msgstr ""
+msgstr "Perché queste informazioni vengono raccolte e come vengono utilizzate"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:31
 msgid "Why this information is collected and how it’s used"
-msgstr ""
+msgstr "Perché queste informazioni vengono raccolte e come vengono utilizzate"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:47
 msgid "You can edit or delete your user provided informations at any time."
-msgstr ""
+msgstr "Puoi modificare o eliminare le informazioni fornite in qualsiasi momento."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:56
 msgid "You may choose to close your account at any time, for any reason."
-msgstr ""
+msgstr "Puoi scegliere di chiudere il tuo account in qualsiasi momento e per qualsiasi motivo."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:34
 msgid "Your email address will remain confidential and is used to log in or in case you forget your password. Moderators are able to set email addresses for accounts to assist in troubleshooting."
-msgstr ""
+msgstr "Il tuo indirizzo e-mail rimarrà privato. Viene utilizzato per effettuare l'accesso o nel caso in cui dimentichi la password. I moderatori possono impostare gli indirizzi e-mail degli account per facilitare la risoluzione dei problemi."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:50
 msgid "Your technical informations are needed for administrative purposes and cannot be deleted."
-msgstr ""
+msgstr "I tuoi dati tecnici sono necessari per scopi di gestione del sito e non possono essere cancellati."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/privacy.html.eex:40
 msgid "Your information will only be disclosed if it is legally necessary to do so. For example, if Listudy is ordered to hand over a certain user’s information, or if someone hacks Listudy."
-msgstr ""
+msgstr "Le tue informazioni saranno divulgate solo se ciò è giuridicamente necessario. Ad esempio, se a Listudy viene ordinato di consegnare le informazioni di un determinato utente, o se qualcuno viola Listudy."

--- a/priv/gettext/it/LC_MESSAGES/statistics.po
+++ b/priv/gettext/it/LC_MESSAGES/statistics.po
@@ -14,7 +14,7 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/stats/index.html.eex:2
 msgid "If you're like me, you can't get enough of stats. Here you can find statistics about Listudy:"
-msgstr "Se sei come me, non ne hai mai abbastanza delle statistiche. Qui puoi trovare le statistiche su Listudy:"
+msgstr "Se sei come me, non ne hai mai abbastanza delle statistiche. Qui puoi trovare le statistiche di Listudy:"
 
 #, elixir-format
 #: lib/listudy_web/templates/stats/index.html.eex:1
@@ -24,9 +24,9 @@ msgstr "Statistiche"
 #, elixir-format
 #: lib/listudy_web/templates/stats/index.html.eex:5
 msgid "Uploaded Studies"
-msgstr "Studi caricati"
+msgstr "Studi Caricati"
 
 #, elixir-format
 #: lib/listudy_web/templates/stats/index.html.eex:11
 msgid "User Registrations"
-msgstr "Registrazioni utente"
+msgstr "Registrazioni Utente"

--- a/priv/gettext/it/LC_MESSAGES/study.po
+++ b/priv/gettext/it/LC_MESSAGES/study.po
@@ -14,506 +14,506 @@ msgstr ""
 #: lib/listudy_web/templates/study/show.html.eex:46
 #, elixir-autogen, elixir-format
 msgid "At the end of lines the board is only reset after 3 seconds giving you time to review the final position."
-msgstr ""
+msgstr "Alla fine delle linee, la scacchiera viene ripristinata solamente dopo 3 secondi, dandoti il tempo di rivedere la posizione finale."
 
 #: lib/listudy_web/templates/study/show.html.eex:144
 #, elixir-autogen, elixir-format
 msgid "Chapter"
-msgstr ""
+msgstr "Capitolo"
 
 #: lib/listudy_web/templates/study/show.html.eex:73
 #, elixir-autogen, elixir-format
 msgid "Chapter Selection"
-msgstr ""
+msgstr "Selezione Capitolo"
 
 #: lib/listudy_web/templates/study/show.html.eex:149
 #, elixir-autogen, elixir-format
 msgid "Create an account to get all the features of Listudy and upload your own studies."
-msgstr ""
+msgstr "Crea un account per ottenere tutte le funzionalità di Listudy e caricare i tuoi studi."
 
 #: lib/listudy_web/templates/study/show.html.eex:88
 #, elixir-autogen, elixir-format
 msgid "Creator"
-msgstr ""
+msgstr "Ideatore"
 
 #: lib/listudy_web/templates/study/form.html.eex:12
 #: lib/listudy_web/templates/study/show.html.eex:81
 #, elixir-autogen, elixir-format
 msgid "Description"
-msgstr ""
+msgstr "Descrizione"
 
 #: lib/listudy_web/templates/study/show.html.eex:150
 #, elixir-autogen, elixir-format
 msgid "Do you have feedback, suggestions or do you want to say something nice? Comment on the study below."
-msgstr ""
+msgstr "Hai commenti, consigli o vuoi dire qualcosa di carino? Commenta lo studio qui sotto."
 
 #: lib/listudy_web/templates/study/show.html.eex:148
 #, elixir-autogen, elixir-format
 msgid "Do you like this study? Share it with your friends."
-msgstr ""
+msgstr "Ti piace questo studio? Condividilo coi tuoi amici."
 
 #: lib/listudy_web/templates/study/list.html.eex:15
 #: lib/listudy_web/templates/study/show.html.eex:85
 #, elixir-autogen, elixir-format
 msgid "Edit"
-msgstr ""
+msgstr "Modifica"
 
 #: lib/listudy_web/templates/study/show.html.eex:34
 #, elixir-autogen, elixir-format
 msgid "Favorite study"
-msgstr ""
+msgstr "Studio preferito"
 
 #: lib/listudy_web/templates/study/show.html.eex:147
 #, elixir-autogen, elixir-format
 msgid "If you like this study make sure to favorite it to have it listed under Your Studies"
-msgstr ""
+msgstr "Se ti piace questo studio, assicurati di marcarlo come preferito per vederlo elencato nella sezione \"I Tuoi Studi\"."
 
 #: lib/listudy_web/templates/study/show.html.eex:52
 #, elixir-autogen, elixir-format
 msgid "Move delay:"
-msgstr ""
+msgstr "Ritardo mossa:"
 
 #: lib/listudy_web/templates/study/form.html.eex:16
 #: lib/listudy_web/templates/study/show.html.eex:91
 #, elixir-autogen, elixir-format
 msgid "Opening"
-msgstr ""
+msgstr "Apertura"
 
 #: lib/listudy_web/templates/study/show.html.eex:23
 #: lib/listudy_web/templates/study/show.html.eex:23
 #, elixir-autogen, elixir-format
 msgid "Play against Stockfish"
-msgstr ""
+msgstr "Gioca contro Stockfish"
 
 #: lib/listudy_web/templates/study/show.html.eex:142
 #, elixir-autogen, elixir-format
 msgid "Right move!"
-msgstr ""
+msgstr "Mossa giusta!"
 
 #: lib/listudy_web/templates/study/show.html.eex:139
 #, elixir-autogen, elixir-format
 msgid "Starting training."
-msgstr ""
+msgstr "Inizio allenamento."
 
 #: lib/listudy_web/templates/study/show.html.eex:141
 #, elixir-autogen, elixir-format
 msgid "This move is not in the study, try again."
-msgstr ""
+msgstr "Questa mossa non è presente nello studio, riprova."
 
 #: lib/listudy_web/templates/study/show.html.eex:151
 #, elixir-autogen, elixir-format
 msgid "You learned 100 moves today. Maybe take a break or come back tomorrow to get the full training effect."
-msgstr ""
+msgstr "Oggi hai imparato 100 mosse. Magari fai una pausa o torna domani per beneficiare completamente degli effetti dell'allenamento."
 
 #: lib/listudy_web/templates/study/show.html.eex:152
 #, elixir-autogen, elixir-format
 msgid "You learned 250 moves today. For the best training effect come back tomorrow. Or don't, I'm just text not a cop."
-msgstr ""
+msgstr "Oggi hai imparato 250 mosse. Per ottenere i risultati migliori nell'allenamento, torna domani. Oppure no, sono solo un messaggio, non un poliziotto."
 
 #: lib/listudy_web/templates/study/show.html.eex:143
 #, elixir-autogen, elixir-format
 msgid "You reached the end of this line."
-msgstr ""
+msgstr "Hai raggiunto la fine di questa linea."
 
 #: lib/listudy_web/templates/study/show.html.eex:165
 #, elixir-autogen, elixir-format
 msgid "fast"
-msgstr ""
+msgstr "veloce"
 
 #: lib/listudy_web/templates/study/show.html.eex:167
 #, elixir-autogen, elixir-format
 msgid "instant"
-msgstr ""
+msgstr "istantaneo"
 
 #: lib/listudy_web/templates/study/show.html.eex:166
 #, elixir-autogen, elixir-format
 msgid "medium"
-msgstr ""
+msgstr "medio"
 
 #: lib/listudy_web/templates/study/show.html.eex:164
 #, elixir-autogen, elixir-format
 msgid "slow"
-msgstr ""
+msgstr "lento"
 
 #: lib/listudy_web/templates/study/form.html.eex:70
 #, elixir-autogen, elixir-format
 msgid "Back"
-msgstr ""
+msgstr "Indietro"
 
 #: lib/listudy_web/templates/study/form.html.eex:9
 #, elixir-autogen, elixir-format
 msgid "Caro-Kann Defense"
-msgstr ""
+msgstr "Difesa Caro-Kann"
 
 #: lib/listudy_web/controllers/study_controller.ex:269
 #, elixir-autogen, elixir-format
 msgid "Could not download the study from lichess, please check the link"
-msgstr ""
+msgstr "Non è stato possibile scaricare lo studio da Lichess, per favore controlla il link"
 
 #: lib/listudy_web/controllers/study_controller.ex:295
 #, elixir-autogen, elixir-format
 msgid "Could not favorite this study"
-msgstr ""
+msgstr "Non è stato possibile impostare lo studio come preferito"
 
 #: lib/listudy_web/controllers/study_controller.ex:313
 #, elixir-autogen, elixir-format
 msgid "Could not unfavorite this study"
-msgstr ""
+msgstr "Non è stato possibile impostare lo studio come non preferito"
 
 #: lib/listudy_web/templates/study/form.html.eex:20
 #, elixir-autogen, elixir-format
 msgid "Either upload a PGN file or provide a link to a public Lichess study:"
-msgstr ""
+msgstr "Carica un file PGN o fornisci un link a uno studio pubblico di Lichess:"
 
 #: lib/listudy_web/templates/study/form.html.eex:38
 #, elixir-autogen, elixir-format
 msgid "For which side is this study"
-msgstr ""
+msgstr "Per quale colore è questo studio"
 
 #: lib/listudy_web/templates/study/form.html.eex:13
 #, elixir-autogen, elixir-format
 msgid "In this study I work on my 1.e4 openings..."
-msgstr ""
+msgstr "In questo studio lavoro sulle mie aperture 1.e4..."
 
 #: lib/listudy_web/templates/study/form.html.eex:43
 #, elixir-autogen, elixir-format
 msgid "Keep this study private"
-msgstr ""
+msgstr "Mantieni questo studio privato"
 
 #: lib/listudy_web/templates/study/form.html.eex:28
 #, elixir-autogen, elixir-format
 msgid "Lichess Study"
-msgstr ""
+msgstr "Studio Lichess"
 
 #: lib/listudy_web/controllers/study_controller.ex:278
 #, elixir-autogen, elixir-format
 msgid "No PGN provided"
-msgstr ""
+msgstr "Nessun PGN fornito"
 
 #: lib/listudy_web/controllers/study_controller.ex:245
 #, elixir-autogen, elixir-format
 msgid "PGN is too big, only 50kb allowed"
-msgstr ""
+msgstr "PGN troppo grande, sono permessi solo 50Kb"
 
 #: lib/listudy_web/controllers/study_controller.ex:227
 #, elixir-autogen, elixir-format
 msgid "Please log in"
-msgstr ""
+msgstr "Per favore, esegui l'accesso"
 
 #: lib/listudy_web/templates/study/form.html.eex:23
 #, elixir-autogen, elixir-format
 msgid "Select a PGN to upload"
-msgstr ""
+msgstr "Seleziona un PGN da caricare"
 
 #: lib/listudy_web/controllers/study_controller.ex:292
 #, elixir-autogen, elixir-format
 msgid "Study favorited"
-msgstr ""
+msgstr "Studio impostato come preferito"
 
 #: lib/listudy_web/controllers/study_controller.ex:171
 #, elixir-autogen, elixir-format
 msgid "Study info updated, PGN changed."
-msgstr ""
+msgstr "Informazioni dello studio aggiornate, PGN modificato."
 
 #: lib/listudy_web/controllers/study_controller.ex:178
 #, elixir-autogen, elixir-format
 msgid "Study info updated, no PGN change."
-msgstr ""
+msgstr "Informazioni dello studio aggiornate, nessuna modifica al PGN."
 
 #: lib/listudy_web/controllers/study_controller.ex:310
 #, elixir-autogen, elixir-format
 msgid "Study unfavorited"
-msgstr ""
+msgstr "Studio impostato come non preferito"
 
 #: lib/listudy_web/controllers/study_controller.ex:273
 #, elixir-autogen, elixir-format
 msgid "The provided link is not a Lichess study"
-msgstr ""
+msgstr "Il link fornito non è uno studio Lichess"
 
 #: lib/listudy_web/templates/study/form.html.eex:8
 #, elixir-autogen, elixir-format
 msgid "Title"
-msgstr ""
+msgstr "Titolo"
 
 #: lib/listudy_web/templates/study/index.html.eex:14
 #, elixir-autogen, elixir-format
 msgid "Create a Study"
-msgstr ""
+msgstr "Crea uno Studio"
 
 #: lib/listudy_web/templates/study/index.html.eex:13
 #, elixir-autogen, elixir-format
 msgid "Create a new study and start learning."
-msgstr ""
+msgstr "Crea un nuovo studio e inizia a imparare."
 
 #: lib/listudy_web/templates/study/index.html.eex:25
 #, elixir-autogen, elixir-format
 msgid "Favored Studies"
-msgstr ""
+msgstr "Studi Preferiti"
 
 #: lib/listudy_web/templates/study/index.html.eex:8
 #, elixir-autogen, elixir-format
 msgid "New Study"
-msgstr ""
+msgstr "Nuovo Studio"
 
 #: lib/listudy_web/templates/study/index.html.eex:15
 #, elixir-autogen, elixir-format
 msgid "Search for Studies"
-msgstr ""
+msgstr "Cerca Studi"
 
 #: lib/listudy_web/templates/study/index.html.eex:1
 #, elixir-autogen, elixir-format
 msgid "Your Studies"
-msgstr ""
+msgstr "I Tuoi Studi"
 
 #: lib/listudy_web/templates/study/new.html.eex:1
 #, elixir-autogen, elixir-format
 msgid "Create a new Study"
-msgstr ""
+msgstr "Crea un nuovo Studio"
 
 #: lib/listudy_web/templates/study/new.html.eex:9
 #, elixir-autogen, elixir-format
 msgid "For more information read the Copyright Policy"
-msgstr ""
+msgstr "Per maggiori informazioni, leggi la Policy di Copyright"
 
 #: lib/listudy_web/templates/study/new.html.eex:8
 #, elixir-autogen, elixir-format
 msgid "Please remember to only upload PGNs for which you have the rights to publish them. This is especially true, but not limited, for PGN files that you have acquired from paid platforms."
-msgstr ""
+msgstr "Ricordati di caricare solo i file PGN per i quali hai i diritti di pubblicazione. Questo vale soprattutto, ma non solo, per i file PGN acquisiti da piattaforme a pagamento."
 
 #: lib/listudy_web/templates/study/edit.html.eex:33
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
-msgstr ""
+msgstr "Sei sicuro?"
 
 #: lib/listudy_web/templates/study/edit.html.eex:33
 #, elixir-autogen, elixir-format
 msgid "Delete"
-msgstr ""
+msgstr "Elimina"
 
 #: lib/listudy_web/templates/study/edit.html.eex:31
 #, elixir-autogen, elixir-format
 msgid "Delete Study"
-msgstr ""
+msgstr "Elimina Studio"
 
 #: lib/listudy_web/templates/study/edit.html.eex:32
 #, elixir-autogen, elixir-format
 msgid "This can not be undone!"
-msgstr ""
+msgstr "Questo non può essere annullato!"
 
 #: lib/listudy_web/live/study_search_live.ex:12
 #, elixir-autogen, elixir-format
 msgid "Search"
-msgstr ""
+msgstr "Cerca"
 
 #: lib/listudy_web/live/study_search_live.ex:10
 #, elixir-autogen, elixir-format
 msgid "Search for studies"
-msgstr ""
+msgstr "Cerca studi"
 
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
 #, elixir-autogen, elixir-format
 msgid "by"
-msgstr ""
+msgstr "di"
 
 #: lib/listudy_web/templates/study/show.html.eex:62
 #, elixir-autogen, elixir-format
 msgid "Don't repeat the early moves that are already known. Skips to the first branching move in the study."
-msgstr ""
+msgstr "Non ripete le prime mosse già conosciute. Salta alla prima ramificazione nello studio."
 
 #: lib/listudy_web/live/study_search_live.ex:14
 #, elixir-autogen, elixir-format
 msgid "Favorites"
-msgstr ""
+msgstr "Favoriti"
 
 #: lib/listudy_web/live/study_search_live.ex:15
 #, elixir-autogen, elixir-format
 msgid "Newest"
-msgstr ""
+msgstr "Più recente"
 
 #: lib/listudy_web/live/study_search_live.ex:24
 #: lib/listudy_web/templates/study/list.html.eex:8
 #, elixir-autogen, elixir-format
 msgid "favorites"
-msgstr ""
+msgstr "favoriti"
 
 #: lib/listudy_web/templates/study/show.html.eex:171
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your study progress?"
-msgstr ""
+msgstr "Sei sicuro di voler cancellare i tuoi progressi nello studio?"
 
 #: lib/listudy_web/templates/study/show.html.eex:68
 #, elixir-autogen, elixir-format
 msgid "Progress"
-msgstr ""
+msgstr "Progresso"
 
 #: lib/listudy_web/templates/study/show.html.eex:186
 #, elixir-autogen, elixir-format
 msgid "Reset progress"
-msgstr ""
+msgstr "Reimposta i progressi"
 
 #: lib/listudy_web/templates/study/show.html.eex:184
 #, elixir-autogen, elixir-format
 msgid "Study Progress"
-msgstr ""
+msgstr "Progressi Studio"
 
 #: lib/listudy_web/templates/study/show.html.eex:27
 #, elixir-autogen, elixir-format
 msgid "Analyze this position with the Lichess Analysis Board"
-msgstr ""
+msgstr "Analizza questa posizione con la Scacchiera d'Analisi di Lichess"
 
 #: lib/listudy_web/templates/study/show.html.eex:161
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: fast"
-msgstr ""
+msgstr "Ritardo di reimpostazione della scacchiera: veloce"
 
 #: lib/listudy_web/templates/study/show.html.eex:160
 #, elixir-autogen, elixir-format
 msgid "Board reset delay: slow"
-msgstr ""
+msgstr "Ritardo di reimpostazione della scacchiera: lento"
 
 #: lib/listudy_web/templates/study/show.html.eex:163
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: off"
-msgstr ""
+msgstr "Salto alla mossa chiave: disattivo"
 
 #: lib/listudy_web/templates/study/show.html.eex:162
 #, elixir-autogen, elixir-format
 msgid "Jump to key move: on"
-msgstr ""
+msgstr "Salto alla mossa chiave: attivo"
 
 #: lib/listudy_web/templates/study/show.html.eex:30
 #, elixir-autogen, elixir-format
 msgid "Reset line"
-msgstr ""
+msgstr "Reimposta linea"
 
 #: lib/listudy_web/templates/study/show.html.eex:13
 #, elixir-autogen, elixir-format
 msgid "Show hints for this move!"
-msgstr ""
+msgstr "Mostra i suggerimenti per questa mossa!"
 
 #: lib/listudy_web/templates/study/show.html.eex:36
 #, elixir-autogen, elixir-format
 msgid "Unfavorite study"
-msgstr ""
+msgstr "Studio non preferito"
 
 #: lib/listudy_web/templates/study/show.html.eex:27
 #, elixir-autogen, elixir-format
 msgid "Analyze position"
-msgstr ""
+msgstr "Analizza posizione"
 
 #: lib/listudy_web/templates/study/show.html.eex:172
 #, elixir-autogen, elixir-format
 msgid "response"
-msgstr ""
+msgstr "risposta"
 
 #: lib/listudy_web/templates/study/show.html.eex:169
 #, elixir-autogen, elixir-format
 msgid "Comments: always on"
-msgstr ""
+msgstr "Commenti: sempre attivi"
 
 #: lib/listudy_web/templates/study/show.html.eex:43
 #, elixir-autogen, elixir-format
 msgid "Option to control when comments are displayed"
-msgstr ""
+msgstr "Opzione per controllare quando visualizzare i commenti"
 
 #: lib/listudy_web/templates/study/show.html.eex:170
 #, elixir-autogen, elixir-format
 msgid "Comments: hidden"
-msgstr ""
+msgstr "Commenti: nascosti"
 
 #: lib/listudy_web/templates/study/show.html.eex:56
 #: lib/listudy_web/templates/study/show.html.eex:173
 #, elixir-autogen, elixir-format
 msgid "Max depth: "
-msgstr ""
+msgstr "Profondità massima: "
 
 #: lib/listudy_web/templates/study/show.html.eex:55
 #, elixir-autogen, elixir-format
 msgid "Lets you choose how many moves deep in the repertoire to train. The highest value you can choose is the length of the longest line. Set to a lower value to train against a more shallow subset of the repertoire, and to the highest value to train against the full repertoire."
-msgstr ""
+msgstr "Permette di scegliere la profondità di mosse del repertorio da allenare. Il valore più alto che si può scegliere è la lunghezza della linea più lunga. Imposta un valore basso per allenarti su un sottoinsieme più ristretto del repertorio, e il valore più alto per allenarti su tutto il repertorio."
 
 #: lib/listudy_web/templates/study/show.html.eex:155
 #, elixir-autogen, elixir-format
 msgid "Hints: always on"
-msgstr ""
+msgstr "Suggerimenti: sempre attivi"
 
 #: lib/listudy_web/templates/study/show.html.eex:156
 #, elixir-autogen, elixir-format
 msgid "Hints: hidden"
-msgstr ""
+msgstr "Suggerimenti: nascosti"
 
 #: lib/listudy_web/templates/study/show.html.eex:153
 #, elixir-autogen, elixir-format
 msgid "Hints: until played 2x"
-msgstr ""
+msgstr "Suggerimenti: finché giocata 2 volte"
 
 #: lib/listudy_web/templates/study/show.html.eex:154
 #, elixir-autogen, elixir-format
 msgid "Hints: until played 5x"
-msgstr ""
+msgstr "Suggerimenti: finché giocata 5 volte"
 
 #: lib/listudy_web/templates/study/show.html.eex:178
 #, elixir-autogen, elixir-format
 msgid "Moves that have been played before are shown with a thinner outline"
-msgstr ""
+msgstr "Le mosse giocate in precedenza sono mostrate con un contorno più sottile."
 
 #: lib/listudy_web/templates/study/show.html.eex:146
 #, elixir-autogen, elixir-format
 msgid "One of the moves in the position has been played more than others and is marked with a thinner outline. To give all lines equal attention, play one of the other moves!"
-msgstr ""
+msgstr "Una delle mosse della posizione è stata giocata più delle altre ed è contraddistinta da un contorno più sottile. Per dare a tutte le linee la stessa importanza, gioca una delle altre mosse!"
 
 #: lib/listudy_web/templates/study/show.html.eex:174
 #, elixir-autogen, elixir-format
 msgid "Opaque arrows with a black outline are playable moves"
-msgstr ""
+msgstr "Le frecce opache con contorno nero sono mosse giocabili."
 
 #: lib/listudy_web/templates/study/show.html.eex:175
 #, elixir-autogen, elixir-format
 msgid "Playable"
-msgstr ""
+msgstr "Giocabile"
 
 #: lib/listudy_web/templates/study/show.html.eex:145
 #, elixir-autogen, elixir-format
 msgid "The transparent arrows are arrows stored in the study. These don't indicate playable moves but are commonly used to indicate threats, alternative lines, and future ideas."
-msgstr ""
+msgstr "Le frecce trasparenti sono frecce salvate nello studio. Non indicano mosse giocabili, ma sono comunemente utilizzate per indicare minacce, linee alternative e idee future."
 
 #: lib/listudy_web/templates/study/show.html.eex:177
 #, elixir-autogen, elixir-format
 msgid "Transparent arrows come from the study and are hints only"
-msgstr ""
+msgstr "Le frecce trasparenti provengono dallo studio e sono solo suggerimenti."
 
 #: lib/listudy_web/templates/study/show.html.eex:176
 #, elixir-autogen, elixir-format
 msgid "Transparent arrows come from the study and are not playable"
-msgstr ""
+msgstr "Le frecce trasparenti provengono dallo studio e non sono giocabili."
 
 #: lib/listudy_web/templates/study/show.html.eex:140
 #, elixir-autogen, elixir-format
 msgid "By default arrows will provide hints to show which moves are in this study. Using the options below you can control for how many moves the arrows/hints should stay visible. By default they stay visible until all moves in a position has been played twice. Any non-playable arrow annotations from the study or PGN file will appear as transparent arrows."
-msgstr ""
+msgstr "Di default le frecce forniranno dei suggerimenti per mostrare quali mosse sono presenti in questo studio. Utilizzando le opzioni sottostanti è possibile controllare per quante mosse le frecce o i suggerimenti devono rimanere visibili. Di default rimangono visibili finché tutte le mosse di una posizione non sono state giocate due volte. Eventuali annotazioni non giocabili dallo studio o dal file PGN appariranno come frecce trasparenti."
 
 #: lib/listudy_web/templates/study/show.html.eex:168
 #, elixir-autogen, elixir-format
 msgid "Comments: when hints show"
-msgstr ""
+msgstr "Commenti: quando vengono mostrati i suggerimenti"
 
 #: lib/listudy_web/templates/study/show.html.eex:49
 #, elixir-autogen, elixir-format
 msgid "Option to control the type of hints shown. 'Moves' means arrows are displayed for all playable moves in the study. 'Annotations' are arrows and circles from the study or PGN file. These can be created at Lichess.org and other sites."
-msgstr ""
+msgstr "Opzione per controllare il tipo di suggerimenti visualizzati. 'Mosse' significa che vengono visualizzate le frecce per tutte le mosse giocabili nello studio. 'Annotazioni' sono frecce e simboli dello studio o del file PGN. Questi possono essere creati su Lichess.org e altri siti."
 
 #: lib/listudy_web/templates/study/show.html.eex:159
 #, elixir-autogen, elixir-format
 msgid "Hints: annotations only"
-msgstr ""
+msgstr "Suggerimenti: solo annotazioni"
 
 #: lib/listudy_web/templates/study/show.html.eex:157
 #, elixir-autogen, elixir-format
 msgid "Hints: moves & annotations"
-msgstr ""
+msgstr "Suggerimenti: mosse e annotazioni"
 
 #: lib/listudy_web/templates/study/show.html.eex:158
 #, elixir-autogen, elixir-format
 msgid "Hints: playable moves only"
-msgstr ""
+msgstr "Suggerimenti: solo mosse giocabili"

--- a/priv/gettext/it/LC_MESSAGES/tactics.po
+++ b/priv/gettext/it/LC_MESSAGES/tactics.po
@@ -73,7 +73,7 @@ msgstr "Trova la mossa migliore per il bianco."
 #, elixir-format
 #: lib/listudy_web/templates/live/blind_tactics.html.leex:23
 msgid "How many plies should be hidden? (Updates next Tactic)"
-msgstr "Quanti livelli devono essere nascosti? (Aggiorna la prossima Tattica)"
+msgstr "Quante semi-mosse devono essere nascoste? (Aggiorna la prossima Tattica)"
 
 #, elixir-format
 #: lib/listudy_web/templates/live/blind_tactics.html.leex:11
@@ -130,7 +130,7 @@ msgstr "Tattica risolta!"
 #, elixir-format
 #: lib/listudy_web/templates/tactic/custom.html.eex:104
 msgid "Use this tactic on your website. Creates an iframe that you can use on you website to share this tactic."
-msgstr "Use questa tattica nel tuo sito web. Crea un iframe che puoi usare nel tuo sito web per condividere questa tattica."
+msgstr "Usa questa tattica nel tuo sito Web. Crea un iframe che puoi usare nel tuo sito Web per condividere questa tattica."
 
 #, elixir-format
 #: lib/listudy_web/templates/live/blind_tactics.html.leex:12
@@ -169,7 +169,7 @@ msgstr "muove e vince."
 #: lib/listudy_web/templates/motif/public.html.eex:8 lib/listudy_web/templates/motif/public.html.eex:14
 #: lib/listudy_web/templates/opening/public.html.eex:44
 msgid "%{name} Tactics"
-msgstr "Tattiche"
+msgstr "%{name} Tattiche"
 
 #, elixir-format
 #: lib/listudy_web/templates/opening/public.html.eex:34
@@ -184,7 +184,7 @@ msgstr "%{opening} dopo le mosse %{moves}"
 #, elixir-format
 #: lib/listudy_web/templates/opening/public.html.eex:9
 msgid "Chessboard showing the %{opening} with the moves %{moves} played"
-msgstr "Scacchiera che mostra la %{opening} con le mosse %{moves} giocate"
+msgstr "La scacchiera mostra la %{opening} con le mosse %{moves} giocate"
 
 #, elixir-format
 #: lib/listudy_web/templates/opening/public.html.eex:12
@@ -224,7 +224,7 @@ msgstr "Migliora nel %{name} risolvendo tattiche."
 #, elixir-format
 #: lib/listudy_web/templates/opening/public.html.eex:38
 msgid "Get better in the %{name} opening by practicing tactics taken from the early game."
-msgstr "Migliora nell'apertura %{name} risolvendo tattiche prese da inizio partita."
+msgstr "Migliora nell'apertura %{name} risolvendo tattiche prese dalle fase iniziale della partita."
 
 #, elixir-format
 #: lib/listudy_web/templates/opening/public.html.eex:27
@@ -260,7 +260,7 @@ msgstr "Gioca la %{name}"
 #, elixir-format
 #: lib/listudy_web/templates/opening/public.html.eex:40
 msgid "Recognize traps and mistakes of your opponents and exploit them."
-msgstr "Riconosci trappole e errori dei tuoi avversari e traine vantaggio."
+msgstr "Identifica le trappole e gli errori dei tuoi avversari e tranne vantaggio."
 
 #, elixir-format
 #: lib/listudy_web/templates/opening/public.html.eex:17
@@ -281,12 +281,12 @@ msgstr "Allena tattiche reali da %{amount} partite diverse."
 #: lib/listudy_web/templates/event/public.html.eex:11
 #: lib/listudy_web/templates/opening/public.html.eex:42
 msgid "Train tactics from %{amount} different games."
-msgstr "Allena tattiche da %{amount} partite diverse."
+msgstr "Allena le tattiche da %{amount} partite diverse."
 
 #, elixir-format
 #: lib/listudy_web/templates/event/public.html.eex:9
 msgid "Solve tactics from games played at %{name}."
-msgstr "Risolvi tattiche da partite giocate al %{name}."
+msgstr "Risolvi tattiche da partite giocate a %{name}."
 
 #, elixir-format
 #: lib/listudy_web/templates/event/public.html.eex:6
@@ -296,7 +296,7 @@ msgstr "Trappole e Tattica da %{name}"
 #, elixir-format
 #: lib/listudy_web/templates/tactic/daily.html.eex:1
 msgid "Daily Chess Puzzle"
-msgstr "Chess Puzzle Giornaliero"
+msgstr "Problema del Giorno"
 
 #, elixir-format
 #: lib/listudy_web/templates/tactic/daily.html.eex:10
@@ -311,7 +311,7 @@ msgstr "Risolvi altre tattiche:"
 #, elixir-format
 #: lib/listudy_web/templates/tactic/daily.html.eex:6
 msgid "Solve the daily chess puzzle. Improve your chess skills every day one tactic at a time."
-msgstr "Risolvi il puzzle giornaliero. Migliora le tue abilità scacchistiche ogni giorno una tattica alla volta."
+msgstr "Risolvi il problema del giorno. Migliora le tue abilità scacchistiche ogni giorno una tattica alla volta."
 
 #, elixir-format
 #: lib/listudy_web/live/motif_search_live.ex:10
@@ -326,120 +326,120 @@ msgstr "Cerca"
 #, elixir-format
 #: lib/listudy_web/templates/live/blind_tactics.html.leex:46
 msgid "Correct move, there are still more moves. They replied with"
-msgstr "Mossa corretta, ci sono ancora altre mosse. Hanno risposto con"
+msgstr "Mossa corretta, ci sono ancora altre mosse. L'avversario ha risposto con"
 
 #, elixir-format
 #: lib/listudy_web/templates/pieceless_tactic/public.html.eex:12
 msgid "%{color} to play."
-msgstr ""
+msgstr "Gioca il %{color}."
 
 #, elixir-format
 #: tactics.html.eex:7
 msgid "All the pieces have disappeared! There is only a list of where the pieces should be next to the board. Can you visualize the position well enough in your head to solve the tactic?"
-msgstr ""
+msgstr "Tutti i pezzi sono scomparsi! C'è solo un elenco accanto alla scacchiera di dove dovrebbero trovarsi i pezzi. Riesci a visualizzare la posizione abbastanza bene nella tua testa da risolvere la tattica?"
 
 #, elixir-format
 #: tactics.html.eex:36
 msgid "Board showing the legal moves if you click on the square of a piece"
-msgstr ""
+msgstr "La scacchiera mostra le mosse legali se fai clic sulla casa in cui è presente un pezzo"
 
 #, elixir-format
 #: lib/listudy_web/templates/pieceless_tactic/public.html.eex:36
 msgid "Correct move, there are still more moves."
-msgstr "Mossa corretta, ci sono ancora altre mosse. Hanno risposto con"
+msgstr "Mossa corretta, ci sono ancora altre mosse."
 
 #, elixir-format
 #: tactics.html.eex:32
 msgid "Have you visualized the position and solved the tactics? Then you can play the solution now."
-msgstr ""
+msgstr "Hai visualizzato la posizione e risolto la tattica? Allora puoi giocare la soluzione ora."
 
 #, elixir-format
 #: tactics.html.eex:42
 #: lib/listudy_web/templates/pieceless_tactic/public.html.eex:14
 msgid "History"
-msgstr ""
+msgstr "Cronologia"
 
 #, elixir-format
 #: tactics.html.eex:13
 msgid "How it works"
-msgstr ""
+msgstr "Come funziona"
 
 #, elixir-format
 #: tactics.html.eex:33
 msgid "If you click on the position on the field on which a piece is standing, you will be shown where the piece can move to. Simply move the piece as you normally would."
-msgstr ""
+msgstr "Se fai clic sulla posizione della casa in cui si trova un pezzo, ti verrà mostrato il punto in cui può spostarsi. Puoi semplicemente muovere il pezzo come faresti normalmente."
 
 #, elixir-format
 #: tactics.html.eex:43
 msgid "If you have made the right move, the history is displayed. There you can see what the AI played in response to your move."
-msgstr ""
+msgstr "Se hai fatto la mossa giusta, viene mostrata la cronologia. Qui puoi vedere cosa ha giocato l'IA in risposta alla tua mossa."
 
 #, elixir-format
 #: tactics.html.eex:19
 msgid "If you load a pieceless tactic, you will be looking at an empty chessboard. Next to the chessboard, however, you will see exactly where the pieces should be placed on the chessboard."
-msgstr ""
+msgstr "Se carichi una tattica senza pezzi, vedrai una scacchiera vuota. Accanto alla scacchiera, tuttavia, vedrai esattamente dove i pezzi devono essere posizionati sulla scacchiera."
 
 #, elixir-format
 #: tactics.html.eex:3
 msgid "Improve your chess visualization skills"
-msgstr ""
+msgstr "Migliora le tue capacità di visualizzazione"
 
 #, elixir-format
 #: tactics.html.eex:44
 msgid "Keep playing until the tactic is solved!"
-msgstr ""
+msgstr "Continua a giocare finché la tattica è risolta!"
 
 #, elixir-format
 #: tactics.html.eex:24
 msgid "Piece list"
-msgstr ""
+msgstr "Elenco dei pezzi"
 
 #, elixir-format
 #: lib/listudy_web/templates/pieceless_tactic/public.html.eex:6
 msgid "Pieceless Tactic"
-msgstr ""
+msgstr "Tattica Senza Pezzi"
 
 #, elixir-format
 #: tactics.html.eex:2
 msgid "Pieceless Tactics"
-msgstr ""
+msgstr "Tattiche Senza Pezzi"
 
 #, elixir-format
 #: tactics.html.eex:10 tactics.html.eex:53
 msgid "Play Now!"
-msgstr ""
+msgstr "Gioca Ora!"
 
 #, elixir-format
 #: tactics.html.eex:31
 msgid "Solve the tactic"
-msgstr "Risolvi altre tattiche:"
+msgstr "Risolvi la tattica"
 
 #, elixir-format
 #: lib/listudy_web/templates/pieceless_tactic/public.html.eex:37
 msgid "Solved!"
-msgstr ""
+msgstr "Risolta!"
 
 #, elixir-format
 #: tactics.html.eex:14
 msgid "Using pieceless tactics takes getting used to. Here I try to explain how to use them as simple and as clear as possible."
-msgstr ""
+msgstr "Giocare le tattiche senza pezzi richiede un po' di tempo per abituarsi. Qui cerco di spiegare come usarle nel modo più semplice e chiaro possibile."
 
 #, elixir-format
 #: tactics.html.eex:18
 msgid "Where are the pieces?"
-msgstr ""
+msgstr "Dove sono i pezzi?"
 
 #, elixir-format
 #: tactics.html.eex:20
 msgid "Your task now is to visualize the pieces on the board and to try to solve the tactic."
-msgstr ""
+msgstr "Il tuo compito adesso è quello di visualizzare i pezzi sulla scacchiera e di cercare di risolvere la tattica."
 
 #, elixir-format
 #: lib/listudy_web/templates/pieceless_tactic/public.html.eex:22
 msgid "[Help] How pieceless tactics work."
-msgstr ""
+msgstr "[Aiuto] Come funzionano le tattiche senza pezzi."
 
 #, elixir-format
 #: tactics.html.eex:48
 msgid "move history showing the moves played"
-msgstr ""
+msgstr "la cronologia delle mosse mostra le mosse giocate"

--- a/priv/gettext/it/LC_MESSAGES/terms.po
+++ b/priv/gettext/it/LC_MESSAGES/terms.po
@@ -14,194 +14,194 @@ msgstr ""
 #, elixir-format
 #: service.html.eex:24
 msgid "Both registered and unregistered users have rights to protect their property, privacy, and identity unless they have consented or agree to making their identity public. Most information on this topic can be found in our Privacy Policy."
-msgstr ""
+msgstr "Sia gli utenti registrati che quelli non registrati hanno il diritto di proteggere la propria proprietà, privacy e identità, a meno che non abbiano acconsentito o accettino di rendere pubblica la propria identità. La maggior parte delle informazioni su questo aspetto sono contenute nella nostra Informativa sulla Privacy."
 
 #, elixir-format
 #: service.html.eex:28
 msgid "By agreeing to these Terms, registered Users can have access to all of Listudy’ features and are free to use them for their own personal, educational, charitable, or developmental purposes. Listudy itself is also free/libre open-source software licensed under the GNU AGPL. This doesn’t prevent Listudy from having the ultimate decision in what kind of use of the Services is appropriate."
-msgstr ""
+msgstr "Accettando questi Termini, gli Utenti registrati possono accedere a tutte le funzionalità di Listudy e sono liberi di utilizzarle per scopi personali, educativi, caritatevoli o di sviluppo. Listudy è esso stesso un software libero e open-source con licenza GNU AGPL. Ciò non impedisce a Listudy di decidere quale tipo di utilizzo dei propri Servizi sia considerato appropriato."
 
 #, elixir-format
 #: service.html.eex:8
 msgid "By using this website (the “Site”) and services (together with the Site, the “Services”) offered by Listudy.org (together with our subsidiaries, affiliates, representatives, and directors – collectively “Listudy”, “we”, or “us”) you’re agreeing to these legally binding rules (the “Terms”). You’re also agreeing to our Privacy Policy and Cookie Policy, and agreeing to follow any other rules on the Site."
-msgstr ""
+msgstr "Utilizzando questo sito Web (il “Sito“) e i servizi (insieme al Sito, i “Servizi“) offerti da Listudy.org (insieme alle nostre sussidiarie, affiliate, rappresentanti e dirigenti - collettivamente “Listudy“, “noi“ o “ci“), accetti queste regole legalmente vincolanti (i “Termini“). Accetti inoltre la nostra Informativa sulla Privacy e l'Informativa sui Cookie e accetti di rispettare tutte le altre regole del Sito."
 
 #, elixir-format
 #: service.html.eex:34
 msgid "Closing and Terminating your Account"
-msgstr ""
+msgstr "Chiudere e Terminare il tuo Account"
 
 #, elixir-format
 #: service.html.eex:55
 msgid "Copyright"
-msgstr ""
+msgstr "Copyright"
 
 #, elixir-format
 #: service.html.eex:12
 msgid "Creating an Account"
-msgstr ""
+msgstr "Creare un Account"
 
 #, elixir-format
 #: service.html.eex:18
 msgid "Don’t impersonate anyone else or choose names that are offensive or that violate anyone’s rights. If you don’t follow these rules, we reserve the right to close your account without warning."
-msgstr ""
+msgstr "Non impersonare nessuno e non scegliere nomi offensivi o che violino i diritti di qualcuno. Se non rispetti queste regole, ci riserviamo il diritto di chiudere il tuo account senza preavviso."
 
 #, elixir-format
 #: service.html.eex:2
 msgid "English version of the Terms of Service"
-msgstr ""
+msgstr "Versione inglese dei Termini di Servizio"
 
 #, elixir-format
 #: service.html.eex:61
 msgid "If you believe your content has been copied in a way that constitutes copyright infringement please alert us by contacting us at copyright@listudy.org."
-msgstr ""
+msgstr "Se ritieni che i tuoi contenuti siano stati copiati in modo da costituire una violazione del diritto d'autore, ti invitiamo ad avvisarci contattandoci all'indirizzo copyright@listudy.org."
 
 #, elixir-format
 #: service.html.eex:32
 msgid "In all circumstances, we may retain certain information as required by law or necessary for our legitimate operating purposes. All of the provisions within this agreement survive the termination of an account."
-msgstr ""
+msgstr "In qualsiasi caso, possiamo conservare alcune informazioni come richiesto dalla legge o necessario per i nostri legittimi scopi operativi. Tutte le disposizioni del presente contratto restano in vigore anche dopo la chiusura dell'account."
 
 #, elixir-format
 #: service.html.eex:4
 msgid "Last edited:"
-msgstr ""
+msgstr "Ultima modifica:"
 
 #, elixir-format
 #: service.html.eex:26
 msgid "Listudy believes that users should have their public information, identity, and data protected as strongly as possible. We use European Union data protection law as our baseline, and in many respects go further than what the law requires. We’ve also chosen to extend these rights to all users, not just those under a European Union jurisdiction."
-msgstr ""
+msgstr "Listudy ritiene che le informazioni pubbliche degli utenti, dalla loro identità e i loro dati debbano essere protetti il più possibile. Utilizziamo la legge sulla protezione dei dati dell'Unione Europea come base di partenza, e per molti aspetti andiamo oltre quanto richiesto da essa. Abbiamo anche scelto di estendere questi diritti a tutti gli utenti, non solo a quelli soggetti alla giurisdizione dell'Unione Europea."
 
 #, elixir-format
 #: service.html.eex:57
 msgid "Listudy is licensed under the GNU AGPL license."
-msgstr ""
+msgstr "Listudy è rilasciato sotto licenza GNU AGPL."
 
 #, elixir-format
 #: service.html.eex:69
 msgid "Listudy makes no warranty or representation and disclaims all responsibility and liability for the completeness, availability, timeliness, accuracy and security of the content and services."
-msgstr ""
+msgstr "Listudy non fornisce alcuna garanzia o assicurazione e declina ogni responsabilità per la completezza, la disponibilità, la tempestività, l'accuratezza e la sicurezza dei contenuti e dei servizi."
 
 #, elixir-format
 #: service.html.eex:59
 msgid "Listudy respects the intellectual property rights of others and expects Users of the Services to do the same. Listudy reserves the right to remove content alleged to be infringing without prior notice at our sole discretion and without liability to you. We will respond to notices of alleged copyright infringement, that comply with applicable law and are properly provided to us, as described in our copyright policy."
-msgstr ""
+msgstr "Listudy rispetta i diritti di proprietà intellettuale degli altri e si aspetta che gli Utenti dei Servizi facciano altrettanto. Listudy si riserva il diritto di rimuovere i contenuti ritenuti in violazione senza preavviso, a sua esclusiva discrezione e senza alcuna responsabilità nei tuoi confronti. Listudy risponderà alle segnalazioni di presunta violazione del copyright, conformi alle leggi vigenti e correttamente fornite, come descritto nella sua policy sul copyright."
 
 #, elixir-format
 #: service.html.eex:73
 msgid "No advice, information or written correspondence whether oral or written procured from Listudy entities or through Listudy services will create any warranty or representation not expressly made herein."
-msgstr ""
+msgstr "Nessun consiglio, informazione o comunicazione, scritta o orale, proveniente da organismi di Listudy o attraverso i servizi Listudy potrà costituire alcuna garanzia o dichiarazione che non sia stata espressamente fornita nel presente documento."
 
 #, elixir-format
 #: service.html.eex:53
 msgid "Our privacy policy describes how we handle the information you provide to us when you use our services. You understand that through your use of the services you consent to the collection and use, as set out in the privacy policy, of this information. Listudy currently follows European Data Protection, and applies these rights to users of all nationalities, not just European users."
-msgstr ""
+msgstr "La nostra informativa sulla privacy descrive il modo in cui gestiamo le informazioni che ci fornisci quando utilizzi i nostri servizi. Sei consapevole del fatto che, utilizzando i servizi, acconsenti alla raccolta e all'utilizzo di tali informazioni, come indicato nell'informativa sulla privacy. Listudy attualmente si attiene alla Protezione dei Dati Europea e applica questi diritti agli utenti di tutte le nazionalità, non solo a quelli europei."
 
 #, elixir-format
 #: service.html.eex:38
 msgid "Our rights"
-msgstr ""
+msgstr "I nostri diritti"
 
 #, elixir-format
 #: service.html.eex:51
 msgid "Privacy"
-msgstr ""
+msgstr "Privacy"
 
 #, elixir-format
 #: service.html.eex:67
 msgid "Services made available are on an as is and as available basis. We’re not responsible for whether this stuff actually works, though if it does that’s an added bonus to all of us."
-msgstr ""
+msgstr "I servizi messi a disposizione sono forniti così come sono e quando disponibili. Non siamo responsabili dell'effettivo funzionamento di queste cose, anche se, se così fosse, sarebbe un vantaggio aggiunto per tutti noi."
 
 #, elixir-format
 #: service.html.eex:65
 msgid "Stuff we’re not responsible for"
-msgstr ""
+msgstr "Cose di cui non siamo responsabili"
 
 #, elixir-format
 #: service.html.eex:49
 msgid "This list is non-exhaustive, and we reserve the right to add, edit, or remove entries from it at any time."
-msgstr ""
+msgstr "Questo elenco non è esaustivo e ci riserviamo il diritto di aggiungere, modificare o rimuovere voci da esso in qualsiasi momento."
 
 #, elixir-format
 #: service.html.eex:6
 msgid "This page explains our terms of use. When you use Listudy, you’re agreeing to all the rules on this page. Some of them need to be expressed in specific legal language but we’ve done our best to offer you clear and simple explanations of what everything means."
-msgstr ""
+msgstr "Questa pagina spiega i nostri termini di utilizzo. Quando utilizzi Listudy, accetti tutte le regole contenute in questa pagina. Alcune di esse devono essere espresse in un linguaggio legale specifico, ma abbiamo fatto del nostro meglio per offrirti spiegazioni chiare e semplici sul significato di ogni cosa."
 
 #, elixir-format
 #: service.html.eex:39
 msgid "To operate, we need to be able to maintain control over what happens on our website. To summarise, we reserve the right to make decisions to protect the health and integrity of our systems. We’ll only use these powers when we absolutely must."
-msgstr ""
+msgstr "Per poter operare, dobbiamo essere in grado di mantenere il controllo su ciò che accade sul nostro sito Web. In sintesi, ci riserviamo il diritto di prendere decisioni per proteggere la salute e l'integrità dei nostri sistemi. Utilizzeremo questi privilegi solo in caso di assoluta necessità."
 
 #, elixir-format
 #: service.html.eex:14
 msgid "To sign up for a Listudy account, you need to be 16 or over. You’re responsible for your account and all the activity on it."
-msgstr ""
+msgstr "Per registrare un account Listudy, è necessario avere almeno 16 anni. Sei responsabile del tuo account e di tutte le attività svolte con esso."
 
 #, elixir-format
 #: service.html.eex:2
 msgid "Translated terms of service shall only serve as an informal source of information. Please read the english version for the official version applicable to the site."
-msgstr ""
+msgstr "I termini di servizio tradotti servono solo come fonte informale di informazioni. Si prega di leggere la versione inglese per conoscere la versione ufficiale applicabile al sito."
 
 #, elixir-format
 #: service.html.eex:22
 msgid "User Rights"
-msgstr ""
+msgstr "Diritti dell'Utente"
 
 #, elixir-format
 #: service.html.eex:30
 msgid "Users are responsible for the content they post. Some examples of content would include information, data, text, and pgn files. We won’t be responsible for the content you post."
-msgstr ""
+msgstr "Gli utenti sono responsabili dei contenuti che pubblicano. Alcuni esempi di contenuti sono informazioni, dati, testi e file PGN. Noi non siamo responsabili dei contenuti da te pubblicati."
 
 #, elixir-format
 #: service.html.eex:45
 msgid "We are not responsible for any loss, damage, or harm that may arise from any occasional downtime."
-msgstr ""
+msgstr "Non siamo responsabili di eventuali perdite, danni o inconvenienti che possono derivare da eventuali tempi di interruzione occasionale dei servizi."
 
 #, elixir-format
 #: service.html.eex:41
 msgid "We can make changes to the Listudy Site and Services without letting you know in advance, or being liable for any loss, damage, or harm that arises as a result."
-msgstr ""
+msgstr "Possiamo apportare modifiche al Sito e ai Servizi di Listudy senza informarti in anticipo o essere responsabili di eventuali perdite, danni o inconvenienti che ne conseguano."
 
 #, elixir-format
 #: service.html.eex:71
 msgid "We disclaim all responsibility for any harm or loss of any data to your computer system, the deletion of or failure to store or transmit communications or content maintained by the services or whether the services will meet your requirements or be available on an uninterrupted, secure or error-free basis. Listudy cannot be held responsible for any loss, financial or otherwise, from third party sources, including misrepresentations, negligence or fraud."
-msgstr ""
+msgstr "Decliniamo ogni responsabilità per eventuali danni o perdite di dati nel tuo sistema informatico, la cancellazione o la mancata memorizzazione o trasmissione di comunicazioni o contenuti conservati nei servizi o se i servizi soddisferanno le tue esigenze o saranno disponibili su base ininterrotta, sicura o priva di errori. Listudy non può essere ritenuto responsabile di eventuali perdite, finanziarie o di altro tipo, derivanti da fonti terze, comprese dichiarazioni errate, negligenza o frode."
 
 #, elixir-format
 #: service.html.eex:43
 msgid "We have the ultimate say in who can use our Site and Services. We can cancel accounts, or decline to let Users use our Services."
-msgstr ""
+msgstr "Abbiamo l'ultima parola su chi può utilizzare il nostro Sito e i nostri Servizi. Possiamo cancellare gli account o rifiutare agli Utenti di utilizzare i nostri Servizi."
 
 #, elixir-format
 #: service.html.eex:10
 msgid "We may change these terms from time to time. If we do, we’ll let you know about any significant or material changes, by notifying you on the Site. New versions of the terms will never apply retroactively – we’ll tell you the exact date they go into effect. If you continue using Listudy after a change, that means you accept the new terms."
-msgstr ""
+msgstr "Le presenti condizioni possono essere modificate di tanto in tanto. In tal caso, ti informeremo di eventuali modifiche significative o materiali, dandotene comunicazione sul Sito. Le nuove versioni dei termini non si applicheranno mai retroattivamente - ti comunicheremo la data esatta della loro entrata in vigore. Se continui a utilizzare Listudy dopo una modifica, significa che accetti i nuovi termini."
 
 #, elixir-format
 #: service.html.eex:47
 msgid "We reserve the right to contact the relevant authorities if a User is breaking the law, and share relevant data with the authorities, if harm or damage occurs either against our Users or against the operation of our infrastructure."
-msgstr ""
+msgstr "Ci riserviamo il diritto di contattare le autorità competenti in caso di violazione della legge da parte di un Utente e di condividere i relativi dati con le autorità, qualora si verifichino danni ai nostri Utenti o al funzionamento della nostra infrastruttura."
 
 #, elixir-format
 #: service.html.eex:20
 msgid "When these terms discuss “Users” or a “User”, we’ll be referring to both registered and unregistered users, unless it relates to features, information or data an unregistered User does not or cannot have access to."
-msgstr ""
+msgstr "Quando in questi termini si parla di “Utenti“ o di “Utente“, ci riferiamo sia agli utenti registrati che a quelli non registrati, a meno che non si tratti di funzionalità, informazioni o dati a cui un Utente non registrato non ha o non può avere accesso."
 
 #, elixir-format
 #: service.html.eex:16
 msgid "You can browse Listudy and use some of our Services without registering an account. But to use all of Listudy’ functions, you’ll need to register. This is done by choosing a username, setting a password, and securing it with an email address. If you don’t submit accurate information, you might not be able to access your account. You can choose any email (even fictitious ones). Just make sure to remember the email, because it is used to log in."
-msgstr ""
+msgstr "Puoi navigare su Listudy e utilizzare alcuni dei nostri Servizi senza registrare un account. Tuttavia, per utilizzare tutte le funzionalità di Listudy, dovrai registrarti. A tal fine, è necessario scegliere un nome utente, impostare una password e proteggerla con un indirizzo e-mail. Se non fornisci informazioni corrette, potresti non essere in grado di accedere al tuo account. È possibile scegliere qualsiasi e-mail (anche fittizia). Assicurati solo di ricordare l'e-mail, perché viene usata per effettuare l'accesso."
 
 #, elixir-format
 #: service.html.eex:35
 msgid "You can close your account at any time."
-msgstr ""
+msgstr "Puoi chiudere il tuo account in qualsiasi momento."
 
 #, elixir-format
 #: service.html.eex:36
 msgid "You can terminate your account at any time by contacting the Listudy administrators. This will permanently erase your account and all content and data. Although we may retain certain information as required by law or as necessary for our legitimate operating purposes. "
-msgstr ""
+msgstr "Puoi chiudere il tuo account in qualsiasi momento contattando gli amministratori di Listudy. In tal modo l'account, tutti i contenuti e i dati verranno cancellati in modo permanente. Tuttavia, possiamo conservare alcune informazioni come richiesto dalla legge o come necessario per i suoi legittimi scopi operativi. "
 
 #, elixir-format
 #: service.html.eex:63
 msgid "You retain your rights to any content you submit, post or create through the services including chess games. By submitting, posting or displaying content on or through our services, you grant us a global, non-exclusive, royalty-free license, with the right to sublicense, to use, copy, reproduce, process, adapt, modify, publish, transmit, display and distribute such content in any and all media or distribution channels. Such additional uses may be made without compensation paid to you with respect to the content you make available through the services. This does not remove your rights from other 3rd party sites, such as Twitch or YouTube."
-msgstr ""
+msgstr "Conservi i tuoi diritti su qualsiasi contenuto che invii, pubblichi o crei attraverso i servizi, comprese le partite di scacchi. Inviando, pubblicando o visualizzando contenuti su o tramite i nostri servizi, concedi una licenza globale, non esclusiva, esente da royalty, con il diritto di sublicenza, per utilizzare, copiare, riprodurre, elaborare, adattare, modificare, pubblicare, trasmettere, visualizzare e distribuire tali contenuti su qualsiasi supporto o canale di distribuzione. Tali impieghi aggiuntivi possono essere esercitati senza che ti venga corrisposto alcun compenso in relazione ai contenuti che rendi disponibili attraverso i servizi. Questo non pregiudica i tuoi diritti nei confronti di altri siti di terze parti, come Twitch o YouTube."

--- a/priv/gettext/it/LC_MESSAGES/thanks.po
+++ b/priv/gettext/it/LC_MESSAGES/thanks.po
@@ -14,44 +14,44 @@ msgstr ""
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:1
 msgid "Thank you!"
-msgstr ""
+msgstr "Grazie!"
 
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:29
 msgid "Thanks to %{cburnett}, Armando Hernandez Marroquin, %{chessnut}, %{letter}, %{pirouetti}, %{pixel}, %{shapes} for their piece sets."
-msgstr ""
+msgstr "Grazie a %{cburnett}, Armando Hernandez Marroquin, %{chessnut}, %{letter}, %{pirouetti}, %{pixel}, %{shapes} per i loro set di pezzi."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:21
 msgid "Thanks to %{jeff} for %{chessjs}."
-msgstr ""
+msgstr "Grazie a %{jeff} per %{chessjs}."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:13
 msgid "Thanks to %{lichess} for all their work. In particular for making studies, their puzzle database (%{database_link}), %{chessground}, and their freely avaliable icons."
-msgstr ""
+msgstr "Grazie a %{lichess} per tutto il loro lavoro. In particolare per la realizzazione degli studi, il loro database di problemi (%{database_link}), %{chessground} e le loro icone liberamente disponibili."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:17
 msgid "Thanks to %{niklas} for %{stockfish}."
-msgstr ""
+msgstr "Grazie a %{niklas} per %{stockfish}."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:6
 msgid "Thanks to all %{contributors}."
-msgstr ""
+msgstr "Grazie a tutti %{contributors}."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:8
 msgid "Thanks to all those who have provided translations."
-msgstr ""
+msgstr "Grazie a tutti coloro che hanno fornito le traduzioni."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:2
 msgid "Thanks to all who have helped directly on Listudy and to all projects that make code and other content openly available. Without this help Listudy could not exist in this form."
-msgstr ""
+msgstr "Grazie a tutti coloro che hanno contribuito direttamente a Listudy e a tutti i progetti che rendono il codice e altri contenuti apertamente disponibili. Senza tale aiuto Listudy non potrebbe esistere in questa forma."
 
 #, elixir-format
 #: lib/listudy_web/templates/page/thanks.html.eex:34
 msgid "Thanks to the authors of %{elixir} and %{phoenix}."
-msgstr ""
+msgstr "Grazie agli autori di %{elixir} e %{phoenix}."

--- a/priv/gettext/it/LC_MESSAGES/webmaster.po
+++ b/priv/gettext/it/LC_MESSAGES/webmaster.po
@@ -14,114 +14,114 @@ msgstr ""
 #, elixir-format
 #: tactics.html.eex:21
 msgid "After you have done this click on the button \"Embed\"."
-msgstr ""
+msgstr "Dopo che hai finito, fai clic sul pulsante \"Incorpora\"."
 
 #, elixir-format
 #: tactics.html.eex:30
 msgid "Automation"
-msgstr ""
+msgstr "Automazione"
 
 #, elixir-format
 #: tactics.html.eex:5 lib/listudy_web/templates/webmaster/index.html.eex:9
 msgid "Bring more interactivity to your tactics. Embed your tactics and let users solve them."
-msgstr ""
+msgstr "Aumenta l'interattività delle tue tattiche. Incorpora le tue tattiche e lascia che gli utenti le risolvano."
 
 #, elixir-format
 #: tactics.html.eex:22
 msgid "Copy the iframe code and paste it into your page."
-msgstr ""
+msgstr "Copia il codice dell'iframe e incollalo nella tua pagina."
 
 #, elixir-format
 #: lib/listudy_web/templates/webmaster/index.html.eex:6
 msgid "Custom Tactics"
-msgstr ""
+msgstr "Tattiche Personalizzate"
 
 #, elixir-format
 #: tactics.html.eex:1
 msgid "Embed Custom Tactics"
-msgstr ""
+msgstr "Incorpora Tattiche Personalizzate"
 
 #, elixir-format
 #: lib/listudy_web/templates/webmaster/index.html.eex:3
 msgid "Embed elements of Listudy on your website."
-msgstr ""
+msgstr "Incorpora elementi di Listudy nel tuo sito Web."
 
 #, elixir-format
 #: tactics.html.eex:20
 msgid "First you have to create your tactics with the tactic creator."
-msgstr ""
+msgstr "Per prima cosa devi creare le tue tattiche con il creatore di tattiche."
 
 #, elixir-format
 #: tactics.html.eex:41
 msgid "For mobile devices it is recommended to limit the width iframes to 100%. Below you will find the css to achieve that."
-msgstr ""
+msgstr "Per i dispositivi mobili si consiglia di limitare la larghezza degli iframe al 100%. Di seguito sono riportati i CSS per ottenere ciò."
 
 #, elixir-format
 #: tactics.html.eex:16
 msgid "How to embed your own Tactics"
-msgstr ""
+msgstr "Come incorporare le tue Tattiche"
 
 #, elixir-format
 #: tactics.html.eex:38
 msgid "Implementation details"
-msgstr ""
+msgstr "Dettagli implementativi"
 
 #, elixir-format
 #: tactics.html.eex:18
 msgid "On the page where you can create your own tactics is an embed button. This button will automatically creates the iframe code that you have to insert on your website."
-msgstr ""
+msgstr "Nella pagina in cui è possibile creare le tue tattiche è presente un pulsante di incorporamento. Questo pulsante creerà automaticamente il codice iframe che devi inserire nel tuo sito Web."
 
 #, elixir-format
 #: tactics.html.eex:33
 msgid "The hash is the base64 encoded string which consists of the fen, the moves and the last move."
-msgstr ""
+msgstr "L'hash è la stringa codificata in base64 che consiste nel FEN, nelle mosse, e nell'ultima mossa."
 
 #, elixir-format
 #: tactics.html.eex:31
 msgid "This process can also be automated. All information needed for tactics are stored in the hash of the embed url."
-msgstr ""
+msgstr "Questo processo può anche essere automatizzato. Tutte le informazioni necessarie per le tattiche sono memorizzate nell'hash dell'URL d'incorporazione."
 
 #, elixir-format
 #: tactics.html.eex:32
 msgid "To generate tactics automatically you can create this hash yourself."
-msgstr ""
+msgstr "Per generare automaticamente le tattiche, puoi creare tu stesso questa hash."
 
 #, elixir-format
 #: tactics.html.eex:25
 msgid "Use this link to create and embed your tactic:"
-msgstr ""
+msgstr "Usa questo link per creare e incorporare la tua tattica:"
 
 #, elixir-format
 #: lib/listudy_web/templates/webmaster/index.html.eex:1
 msgid "Webmaster"
-msgstr ""
+msgstr "Webmaster"
 
 #, elixir-format
 #: tactics.html.eex:39
 msgid "You can change the standard width and height if you wish. Just make sure that the height is about 80px higher than the width so that the \"x to play\" message fits under the board."
-msgstr ""
+msgstr "Se lo desideri, puoi modificare la larghezza e l'altezza standard. Assicurati che l'altezza sia superiore di circa 80px rispetto alla larghezza, in modo che il messaggio \"mossa al X\" si posizioni sotto la scacchiera."
 
 #, elixir-format
 #: tactics.html.eex:7
 msgid "You can specify the position, what the right moves are and what the last move was."
-msgstr ""
+msgstr "Puoi specificare la posizione, le mosse giuste e qual è stata l'ultima mossa."
 
 #, elixir-format
 #: tactics.html.eex:6
 msgid "You have full control over the tactics."
-msgstr ""
+msgstr "Hai pieno controllo sulle tattiche."
 
 #, elixir-format
 #: lib/listudy_web/templates/webmaster/index.html.eex:12
 msgid "Learn More"
-msgstr ""
+msgstr "Per saperne di più"
 
 #, elixir-format
 #: tactics.html.eex:26
 msgid "Create your own Tactic"
-msgstr ""
+msgstr "Crea la tua Tattica"
 
 #, elixir-format
 #: tactics.html.eex:35
 msgid "The values are each separated by a \";\". The moves must be in san notation and the last move in uci notation."
-msgstr ""
+msgstr "I valori sono separati da un \";\". Le mosse devono essere in notazione SAN e l'ultima mossa in notazione UCI."


### PR DESCRIPTION
These changes extend and improve the previous Italian translations. Most of the translations were missing, likely because copies were simply not present at that time. Some typos have been fixed and sentences adjusted to make them sound more natural.

Please, note that in the template [recommended.html.eex](https://github.com/ArneVogel/listudy/blob/master/lib/listudy_web/templates/book/recommended.html.eex#L1), the two `msgid`s `"Grandmaster recommended"` and `"Chess Books"` can not work in this order in Italian (and many other languages). To make the outcome meaningful, I had to swap the two translations (i.e. `"Grandmaster recommended"` translated as `"Chess Books"`, and vice versa). This is because the same sentence is split into two chunks displayed in a given order, which simply doesn't work.
I strongly recommend introducing one single key (`"Grandmaster recommended Chess Books"`) and adjusting the template to shrink the title in a way the text is distributed over two lines (if this is really the wanted effect). Needless to say, all translations should be adapted after that.